### PR TITLE
Adding LLVM-21 Support

### DIFF
--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        llvm: ["20"]
+        llvm: ["20", "21"]
         build: ["Release"] #, "Debug"] #, "RelWithDebInfo"]
         os: [ubuntu-22.04]
 

--- a/Readme.md
+++ b/Readme.md
@@ -118,16 +118,16 @@ or if using `lld` directly:
 
 Suppose your original code looks like this:
 ``` c++
-void bar(float a, float b) {
+float bar(float a, float b) {
   return a + b;
 }
-void foo(float *a, float b) {
+float foo(float *a, float b) {
   a[0] = sqrt(b);
   return bar(a[1], b);
 }
 
   ...
-  foo(a, b)
+  foo(a, b);
   ...
 ```
 

--- a/pass/Raptor.cpp
+++ b/pass/Raptor.cpp
@@ -937,7 +937,7 @@ public:
           for (size_t i : {0, 2}) {
             if (i < num_args &&
                 CI->getArgOperand(i)->getType()->isPointerTy()) {
-							addNoCapture(CI, i);
+              addNoCapture(CI, i);
             }
           }
         }

--- a/pass/Raptor.cpp
+++ b/pass/Raptor.cpp
@@ -109,7 +109,11 @@ bool attributeKnownFunctions(llvm::Function &F) {
   if (F.getName() == "fprintf") {
     for (auto &arg : F.args()) {
       if (arg.getType()->isPointerTy()) {
+#if LLVM_VERSION_MAJOR >= 21
+        arg.addAttr(Attribute::get(F.getContext(), "captures", "none"));
+#else
         arg.addAttr(Attribute::NoCapture);
+#endif
         changed = true;
       }
     }
@@ -132,7 +136,11 @@ bool attributeKnownFunctions(llvm::Function &F) {
       for (auto &arg : F.args()) {
         if (arg.getType()->isPointerTy()) {
           arg.addAttr(Attribute::ReadNone);
+#if LLVM_VERSION_MAJOR >= 21
+          arg.addAttr(Attribute::get(F.getContext(), "captures", "none"));
+#else
           arg.addAttr(Attribute::NoCapture);
+#endif
         }
       }
   }
@@ -152,7 +160,11 @@ bool attributeKnownFunctions(llvm::Function &F) {
     F.addFnAttr(Attribute::NoSync);
     for (int i = 0; i < 2; i++)
       if (F.getFunctionType()->getParamType(i)->isPointerTy()) {
+#if LLVM_VERSION_MAJOR >= 21
+        F.addParamAttr(i, Attribute::get(F.getContext(), "captures", "none"));
+#else
         F.addParamAttr(i, Attribute::NoCapture);
+#endif
         F.addParamAttr(i, Attribute::WriteOnly);
       }
   }
@@ -176,7 +188,11 @@ bool attributeKnownFunctions(llvm::Function &F) {
     F.addFnAttr(Attribute::NoSync);
     F.addParamAttr(0, Attribute::WriteOnly);
     if (F.getFunctionType()->getParamType(2)->isPointerTy()) {
+#if LLVM_VERSION_MAJOR >= 21
+      F.addParamAttr(2, Attribute::get(F.getContext(), "captures", "none"));
+#else
       F.addParamAttr(2, Attribute::NoCapture);
+#endif
       F.addParamAttr(2, Attribute::WriteOnly);
     }
     F.addParamAttr(6, Attribute::WriteOnly);
@@ -195,7 +211,11 @@ bool attributeKnownFunctions(llvm::Function &F) {
     F.addFnAttr(Attribute::NoSync);
     F.addParamAttr(0, Attribute::ReadOnly);
     if (F.getFunctionType()->getParamType(2)->isPointerTy()) {
+#if LLVM_VERSION_MAJOR >= 21
+      F.addParamAttr(2, Attribute::get(F.getContext(), "captures", "none"));
+#else
       F.addParamAttr(2, Attribute::NoCapture);
+#endif
       F.addParamAttr(2, Attribute::ReadOnly);
     }
     F.addParamAttr(6, Attribute::WriteOnly);
@@ -215,12 +235,20 @@ bool attributeKnownFunctions(llvm::Function &F) {
     F.addFnAttr(Attribute::NoSync);
 
     if (F.getFunctionType()->getParamType(0)->isPointerTy()) {
+#if LLVM_VERSION_MAJOR >= 21
+      F.addParamAttr(0, Attribute::get(F.getContext(), "captures", "none"));
+#else
       F.addParamAttr(0, Attribute::NoCapture);
+#endif
       F.addParamAttr(0, Attribute::ReadOnly);
     }
     if (F.getFunctionType()->getParamType(1)->isPointerTy()) {
       F.addParamAttr(1, Attribute::WriteOnly);
+#if LLVM_VERSION_MAJOR >= 21
+      F.addParamAttr(1, Attribute::get(F.getContext(), "captures", "none"));
+#else
       F.addParamAttr(1, Attribute::NoCapture);
+#endif
     }
   }
   if (F.getName() == "MPI_Wait" || F.getName() == "PMPI_Wait") {
@@ -230,9 +258,14 @@ bool attributeKnownFunctions(llvm::Function &F) {
     F.addFnAttr(Attribute::WillReturn);
     F.addFnAttr(Attribute::NoFree);
     F.addFnAttr(Attribute::NoSync);
+#if LLVM_VERSION_MAJOR >= 21
+    F.addParamAttr(0, Attribute::get(F.getContext(), "captures", "none"));
+    F.addParamAttr(1, Attribute::get(F.getContext(), "captures", "none"));
+#else
     F.addParamAttr(0, Attribute::NoCapture);
-    F.addParamAttr(1, Attribute::WriteOnly);
     F.addParamAttr(1, Attribute::NoCapture);
+#endif
+    F.addParamAttr(1, Attribute::WriteOnly);
   }
   if (F.getName() == "MPI_Waitall" || F.getName() == "PMPI_Waitall") {
     changed = true;
@@ -241,9 +274,14 @@ bool attributeKnownFunctions(llvm::Function &F) {
     F.addFnAttr(Attribute::WillReturn);
     F.addFnAttr(Attribute::NoFree);
     F.addFnAttr(Attribute::NoSync);
+#if LLVM_VERSION_MAJOR >= 21
+    F.addParamAttr(1, Attribute::get(F.getContext(), "captures", "none"));
+    F.addParamAttr(2, Attribute::get(F.getContext(), "captures", "none"));
+#else
     F.addParamAttr(1, Attribute::NoCapture);
-    F.addParamAttr(2, Attribute::WriteOnly);
     F.addParamAttr(2, Attribute::NoCapture);
+#endif
+    F.addParamAttr(2, Attribute::WriteOnly);
   }
   // Map of MPI function name to the arg index of its type argument
   std::map<std::string, int> MPI_TYPE_ARGS = {
@@ -825,9 +863,14 @@ public:
           CI->addAttribute(AttributeList::FunctionIndex, Attribute::ReadOnly);
 #endif
           CI->addParamAttr(1, Attribute::ReadOnly);
-          CI->addParamAttr(1, Attribute::NoCapture);
           CI->addParamAttr(3, Attribute::ReadOnly);
+#if LLVM_VERSION_MAJOR >= 21
+          CI->addParamAttr(1, Attribute::get(CI->getContext(), "captures", "none"));
+          CI->addParamAttr(3, Attribute::get(CI->getContext(), "captures", "none"));
+#else
+          CI->addParamAttr(1, Attribute::NoCapture);
           CI->addParamAttr(3, Attribute::NoCapture);
+#endif
         }
         if (Fn->getName() == "frexp" || Fn->getName() == "frexpf" ||
             Fn->getName() == "frexpl") {
@@ -888,7 +931,11 @@ public:
           for (size_t i : {0, 1}) {
             if (i < num_args &&
                 CI->getArgOperand(i)->getType()->isPointerTy()) {
+#if LLVM_VERSION_MAJOR >= 21
+              CI->addParamAttr(i, Attribute::get(CI->getContext(), "captures", "none"));
+#else
               CI->addParamAttr(i, Attribute::NoCapture);
+#endif
             }
           }
         }
@@ -913,7 +960,11 @@ public:
           for (size_t i : {0, 2}) {
             if (i < num_args &&
                 CI->getArgOperand(i)->getType()->isPointerTy()) {
+#if LLVM_VERSION_MAJOR >= 21
+              CI->addParamAttr(i, Attribute::get(CI->getContext(), "captures", "none"));
+#else
               CI->addParamAttr(i, Attribute::NoCapture);
+#endif
             }
           }
         }
@@ -939,7 +990,11 @@ public:
           for (size_t i : {0, 1, 2, 3}) {
             if (i < num_args &&
                 CI->getArgOperand(i)->getType()->isPointerTy()) {
+#if LLVM_VERSION_MAJOR >= 21
+              CI->addParamAttr(i, Attribute::get(CI->getContext(), "captures", "none"));
+#else
               CI->addParamAttr(i, Attribute::NoCapture);
+#endif
             }
           }
         }
@@ -965,7 +1020,11 @@ public:
           for (size_t i : {0}) {
             if (i < num_args &&
                 CI->getArgOperand(i)->getType()->isPointerTy()) {
+#if LLVM_VERSION_MAJOR >= 21
+              CI->addParamAttr(i, Attribute::get(CI->getContext(), "captures", "none"));
+#else
               CI->addParamAttr(i, Attribute::NoCapture);
+#endif
             }
           }
         }
@@ -987,7 +1046,11 @@ public:
           for (size_t i = 0; i < num_args; ++i) {
             if (CI->getArgOperand(i)->getType()->isPointerTy()) {
               CI->addParamAttr(i, Attribute::ReadOnly);
+#if LLVM_VERSION_MAJOR >= 21
+              CI->addParamAttr(i, Attribute::get(CI->getContext(), "captures", "none"));
+#else
               CI->addParamAttr(i, Attribute::NoCapture);
+#endif
             }
           }
         }

--- a/test/Integration/Truncate/Fortran/simple-no-bindc.f90
+++ b/test/Integration/Truncate/Fortran/simple-no-bindc.f90
@@ -1,3 +1,6 @@
+! ! Circumvent tests in versions where LLVM ships with a non-functional flang
+! ! (see https://github.com/llvm/llvm-project/issues/138340 )
+! XFAIL: %LLVM_MAJOR == 21 || %LLVM_MAJOR == 22
 ! RUN: %flang -O1 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s
 ! RUN: %flang -O2 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s
 ! RUN: %flang -O3 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s

--- a/test/Integration/Truncate/Fortran/simple-no-bindc.f90
+++ b/test/Integration/Truncate/Fortran/simple-no-bindc.f90
@@ -1,6 +1,6 @@
 ! ! Circumvent tests in versions where LLVM ships with a non-functional flang
 ! ! (see https://github.com/llvm/llvm-project/issues/138340 )
-! XFAIL: %LLVM_MAJOR == 21 || %LLVM_MAJOR == 22
+! XFAIL: llvm-major:{{21|22}}
 ! RUN: %flang -O1 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s
 ! RUN: %flang -O2 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s
 ! RUN: %flang -O3 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s

--- a/test/Integration/Truncate/Fortran/simple-no-bindc.f90
+++ b/test/Integration/Truncate/Fortran/simple-no-bindc.f90
@@ -1,6 +1,6 @@
 ! ! Circumvent tests in versions where LLVM ships with a non-functional flang
 ! ! (see https://github.com/llvm/llvm-project/issues/138340 )
-! XFAIL: llvm-major:{{21|22}}
+! XFAIL: llvm-major={{21|22}}
 ! RUN: %flang -O1 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s
 ! RUN: %flang -O2 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s
 ! RUN: %flang -O3 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s

--- a/test/Integration/Truncate/Fortran/simple.f90
+++ b/test/Integration/Truncate/Fortran/simple.f90
@@ -1,6 +1,6 @@
 ! ! Circumvent tests in versions where LLVM ships with a non-functional flang
 ! ! (see https://github.com/llvm/llvm-project/issues/138340 )
-! XFAIL: %LLVM_MAJOR == 21 || %LLVM_MAJOR == 22
+! XFAIL: llvm-major:{{21|22}}
 ! RUN: %flang -O0 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s
 ! RUN: %flang -O1 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s
 ! RUN: %flang -O2 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s

--- a/test/Integration/Truncate/Fortran/simple.f90
+++ b/test/Integration/Truncate/Fortran/simple.f90
@@ -1,6 +1,6 @@
 ! ! Circumvent tests in versions where LLVM ships with a non-functional flang
 ! ! (see https://github.com/llvm/llvm-project/issues/138340 )
-! XFAIL: llvm-major:{{21|22}}
+! XFAIL: llvm-major={{21|22}}
 ! RUN: %flang -O0 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s
 ! RUN: %flang -O1 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s
 ! RUN: %flang -O2 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s

--- a/test/Integration/Truncate/Fortran/simple.f90
+++ b/test/Integration/Truncate/Fortran/simple.f90
@@ -1,3 +1,6 @@
+! ! Circumvent tests in versions where LLVM ships with a non-functional flang
+! ! (see https://github.com/llvm/llvm-project/issues/138340 )
+! XFAIL: %LLVM_MAJOR == 21 || %LLVM_MAJOR == 22
 ! RUN: %flang -O0 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s
 ! RUN: %flang -O1 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s
 ! RUN: %flang -O2 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s

--- a/test/Unit/Truncate/intrinsic.ll
+++ b/test/Unit/Truncate/intrinsic.ll
@@ -45,7 +45,7 @@ entry:
 ; CHECK-DAG:   call double @__raptor_fprt_ieee_64_intr_llvm_pow_f64(
 ; CHECK-DAG:   call double @__raptor_fprt_ieee_64_intr_llvm_powi_f64_i16(
 ; CHECK-DAG:   call double @__raptor_fprt_ieee_64_binop_fadd(
-; CHECK-DAG:   call void @llvm.nvvm.barrier0()
+; CHECK-DAG:   call void @llvm.nvvm.barrier
 
 ; CHECK: define internal double @__raptor_done_truncate_op_func_ieee_64_to_ieee_32_0_0_0_f(
 ; CHECK-DAG:   fptrunc
@@ -58,4 +58,4 @@ entry:
 ; CHECK-DAG:   call double @__raptor_fprt_ieee_64_intr_llvm_pow_f64(
 ; CHECK-DAG:   call double @__raptor_fprt_ieee_64_intr_llvm_powi_f64_i16(
 ; CHECK-DAG:   call double @__raptor_fprt_ieee_64_binop_fadd(
-; CHECK-DAG:   call void @llvm.nvvm.barrier0()
+; CHECK-DAG:   call void @llvm.nvvm.barrier

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -44,6 +44,9 @@ except KeyError:
 # directories.
 config.excludes = ['Inputs']
 
+# Used when checking for major LLVM versions if tests are expected to fail
+config.substitutions.append(('%LLVM_MAJOR', config.llvm_ver))
+
 config.substitutions.append(('%shlibext', config.llvm_shlib_ext))
 config.substitutions.append(('%lli', config.llvm_tools_dir + "/lli" + (" --jit-kind=mcjit" if int(config.llvm_ver) >= 13 else "")
 ))

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -45,7 +45,7 @@ except KeyError:
 config.excludes = ['Inputs']
 
 # Used when checking for major LLVM versions if tests are expected to fail
-config.substitutions.append(('%LLVM_MAJOR', config.llvm_ver))
+config.available_features.add('llvm-major:' + config.llvm_ver)
 
 config.substitutions.append(('%shlibext', config.llvm_shlib_ext))
 config.substitutions.append(('%lli', config.llvm_tools_dir + "/lli" + (" --jit-kind=mcjit" if int(config.llvm_ver) >= 13 else "")

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -45,7 +45,7 @@ except KeyError:
 config.excludes = ['Inputs']
 
 # Used when checking for major LLVM versions if tests are expected to fail
-config.available_features.add('llvm-major:' + config.llvm_ver)
+config.available_features.add('llvm-major=' + config.llvm_ver)
 
 config.substitutions.append(('%shlibext', config.llvm_shlib_ext))
 config.substitutions.append(('%lli', config.llvm_tools_dir + "/lli" + (" --jit-kind=mcjit" if int(config.llvm_ver) >= 13 else "")


### PR DESCRIPTION
This pull request changes the way `Attribute::NoCapture` is handled when LLVM MAJOR >= 21. This makes RAPTOR compile using LLVM 21.