### PR TITLE
Support standard math lib functions ending with "f"

### DIFF
--- a/pass/RaptorLogic.cpp
+++ b/pass/RaptorLogic.cpp
@@ -265,7 +265,7 @@ public:
           C = '_';
     } else if (auto CI = dyn_cast<CallInst>(&I)) {
       if (auto F = CI->getCalledFunction())
-        Name = "func_" + std::string(F->getName());
+        Name = "func_" + clipLibMFuncTrailingfl(std::string(F->getName()));
       else
         llvm_unreachable(
             "Unexpected indirect call inst for conversion to FPRT");

--- a/pass/Utils.h
+++ b/pass/Utils.h
@@ -180,6 +180,28 @@ static inline bool isMemFreeLibMFunction(llvm::StringRef str,
   return false;
 }
 
+static inline std::string clipLibMFuncTrailingfl(std::string s) {
+  unsigned prefix_size = 0;
+  unsigned suffix_size = 0;
+  if ((s.substr(0,2) == "__") && (s.substr(s.size() - 7, 7) == "_finite")) {
+    prefix_size = 2;
+    suffix_size = 7;
+  } else if ((s.substr(0,5) == "__fd_") && (s.substr(s.size() - 2, 2) == "_1")) {
+    prefix_size = 5;
+    suffix_size = 2;
+  } else if (s.substr(0,5) == "__nv_") {
+    prefix_size = 5;
+  }
+  auto func_name = s.substr(prefix_size, s.size() - prefix_size - suffix_size);
+  if (LIBM_FUNCTIONS.find(func_name) == LIBM_FUNCTIONS.end() && 
+      ((func_name.back() == 'f') || (func_name.back() == 'l')) &&
+      LIBM_FUNCTIONS.find(func_name.substr(0, func_name.size() - 1)) != 
+      LIBM_FUNCTIONS.end()) {
+    s.erase(s.size() - suffix_size - 1, 1);
+  }
+  return s;
+}
+
 
 
 #endif // RAPTOR_UTILS

--- a/runtime/ir/Flops.def
+++ b/runtime/ir/Flops.def
@@ -16,6 +16,25 @@
   __RAPTOR_MPFR_BIN(func, __##LLVM_OP_NAME##_finite, MPFR_FUNC_NAME, ieee_64,    \
                     double, d, double, d, double, d, ROUNDING_MODE)
 
+#define __RAPTOR_MPFR_DOUBLE_FLOAT_BINFUNCINTR(LLVM_OP_NAME, MPFR_FUNC_NAME,         \
+                                         ROUNDING_MODE)                        \
+  __RAPTOR_MPFR_BIN(intr, LLVM_OP_NAME, MPFR_FUNC_NAME, ieee_64, double, d,      \
+                    double, d, double, d, ROUNDING_MODE)                       \
+  __RAPTOR_MPFR_BIN(intr, llvm_##LLVM_OP_NAME##_f64, MPFR_FUNC_NAME, ieee_64,    \
+                    double, d, double, d, double, d, ROUNDING_MODE)            \
+  __RAPTOR_MPFR_BIN(func, LLVM_OP_NAME, MPFR_FUNC_NAME, ieee_64, double, d,      \
+                    double, d, double, d, ROUNDING_MODE)                       \
+  __RAPTOR_MPFR_BIN(func, __##LLVM_OP_NAME##_finite, MPFR_FUNC_NAME, ieee_64,    \
+                    double, d, double, d, double, d, ROUNDING_MODE)            \
+  __RAPTOR_MPFR_BIN(intr, LLVM_OP_NAME, MPFR_FUNC_NAME, ieee_32, float, d,      \
+                    float, d, float, d, ROUNDING_MODE)                       \
+  __RAPTOR_MPFR_BIN(intr, llvm_##LLVM_OP_NAME##_f32, MPFR_FUNC_NAME, ieee_32,    \
+                    float, d, float, d, float, d, ROUNDING_MODE)            \
+  __RAPTOR_MPFR_BIN(func, LLVM_OP_NAME, MPFR_FUNC_NAME, ieee_32, float, d,      \
+                    float, d, float, d, ROUNDING_MODE)                       \
+  __RAPTOR_MPFR_BIN(func, __##LLVM_OP_NAME##_finite, MPFR_FUNC_NAME, ieee_32,    \
+                    float, d, float, d, float, d, ROUNDING_MODE)
+
 #define __RAPTOR_MPFR_DOUBLE_BINOP_DEFAULT_ROUNDING(LLVM_OP_NAME,              \
                                                     MPFR_FUNC_NAME)            \
   __RAPTOR_MPFR_DOUBLE_BINOP(LLVM_OP_NAME, MPFR_FUNC_NAME,                     \
@@ -24,6 +43,11 @@
 #define __RAPTOR_MPFR_DOUBLE_BINFUNCINTR_DEFAULT_ROUNDING(LLVM_OP_NAME,        \
                                                           MPFR_FUNC_NAME)      \
   __RAPTOR_MPFR_DOUBLE_BINFUNCINTR(LLVM_OP_NAME, MPFR_FUNC_NAME,               \
+                                   __RAPTOR_MPFR_DEFAULT_ROUNDING_MODE)
+
+#define __RAPTOR_MPFR_DOUBLE_FLOAT_BINFUNCINTR_DEFAULT_ROUNDING(LLVM_OP_NAME,        \
+                                                          MPFR_FUNC_NAME)      \
+  __RAPTOR_MPFR_DOUBLE_FLOAT_BINFUNCINTR(LLVM_OP_NAME, MPFR_FUNC_NAME,               \
                                    __RAPTOR_MPFR_DEFAULT_ROUNDING_MODE)
 
 #define __RAPTOR_MPFR_SINGOP_DOUBLE_FLOAT(LLVM_NAME, MPFR_NAME)                \
@@ -57,15 +81,15 @@ __RAPTOR_MPFR_DOUBLE_BINOP_DEFAULT_ROUNDING(fsub, sub);
 __RAPTOR_MPFR_DOUBLE_BINOP_DEFAULT_ROUNDING(fdiv, div);
 __RAPTOR_MPFR_DOUBLE_BINOP_DEFAULT_ROUNDING(frem, remainder);
 
-__RAPTOR_MPFR_DOUBLE_BINFUNCINTR_DEFAULT_ROUNDING(pow, pow);
-__RAPTOR_MPFR_DOUBLE_BINFUNCINTR_DEFAULT_ROUNDING(copysign, copysign);
-__RAPTOR_MPFR_DOUBLE_BINFUNCINTR_DEFAULT_ROUNDING(fdim, dim);
-__RAPTOR_MPFR_DOUBLE_BINFUNCINTR_DEFAULT_ROUNDING(remainder, remainder);
-__RAPTOR_MPFR_DOUBLE_BINFUNCINTR_DEFAULT_ROUNDING(atan2, atan2);
-__RAPTOR_MPFR_DOUBLE_BINFUNCINTR_DEFAULT_ROUNDING(hypot, hypot);
-__RAPTOR_MPFR_DOUBLE_BINFUNCINTR_DEFAULT_ROUNDING(fmod, fmod);
-__RAPTOR_MPFR_DOUBLE_BINFUNCINTR_DEFAULT_ROUNDING(maxnum, max);
-__RAPTOR_MPFR_DOUBLE_BINFUNCINTR_DEFAULT_ROUNDING(minnum, min);
+__RAPTOR_MPFR_DOUBLE_FLOAT_BINFUNCINTR_DEFAULT_ROUNDING(pow, pow);
+__RAPTOR_MPFR_DOUBLE_FLOAT_BINFUNCINTR_DEFAULT_ROUNDING(copysign, copysign);
+__RAPTOR_MPFR_DOUBLE_FLOAT_BINFUNCINTR_DEFAULT_ROUNDING(fdim, dim);
+__RAPTOR_MPFR_DOUBLE_FLOAT_BINFUNCINTR_DEFAULT_ROUNDING(remainder, remainder);
+__RAPTOR_MPFR_DOUBLE_FLOAT_BINFUNCINTR_DEFAULT_ROUNDING(atan2, atan2);
+__RAPTOR_MPFR_DOUBLE_FLOAT_BINFUNCINTR_DEFAULT_ROUNDING(hypot, hypot);
+__RAPTOR_MPFR_DOUBLE_FLOAT_BINFUNCINTR_DEFAULT_ROUNDING(fmod, fmod);
+__RAPTOR_MPFR_DOUBLE_FLOAT_BINFUNCINTR_DEFAULT_ROUNDING(maxnum, max);
+__RAPTOR_MPFR_DOUBLE_FLOAT_BINFUNCINTR_DEFAULT_ROUNDING(minnum, min);
 
 __RAPTOR_MPFR_BIN_INT(intr, llvm_powi_f64_i32, pow_si, ieee_64, double, d, double,
                       d, int32_t, __RAPTOR_MPFR_DEFAULT_ROUNDING_MODE);


### PR DESCRIPTION
Fix linker error for standard math lib functions already included in `runtime/ir/Flops.def` ending with "f" mentioned in #10.

Removed the ending "f"/"l" from the corresponding __raptor_fprt function names.
Added definitions for float type standard math lib functions with 2 input parameters (on top of the existing double type).