### PR TITLE
Add support for 32/16-bit mem-mode truncation through assigning 32/16-bit ID

### DIFF
--- a/runtime/include/private/raptor/Common.h
+++ b/runtime/include/private/raptor/Common.h
@@ -4,6 +4,8 @@
 #include <atomic>
 #include <cstdlib>
 #include <cstring>
+#include <type_traits>
+#include <vector>
 #include <mpfr.h>
 
 #define MAX_MPFR_OPERANDS 3
@@ -17,6 +19,12 @@
 
 extern std::atomic<long long> shadow_err_counter;
 extern std::atomic<bool> global_is_truncating;
+
+typedef union __raptor_fp_id {
+  size_t d;
+  uint32_t f;
+  uint16_t h;
+} __raptor_fp_id;
 
 typedef struct __raptor_op {
   const char *op;             // Operation name
@@ -33,6 +41,7 @@ typedef struct __raptor_fp {
   // #ifdef RAPTOR_FPRT_ENABLE_SHADOW_RESIDUALS
   double excl_result;
   double shadow;
+  __raptor_fp_id id;
   // #endif
 } __raptor_fp;
 
@@ -73,6 +82,60 @@ template <typename To, typename From> To checked_raptor_bitcast(From from) {
     abort();
 }
 
+template <typename CPP_TY>
+std::enable_if_t<
+  std::is_floating_point_v<CPP_TY> && sizeof(CPP_TY) == sizeof(__raptor_fp *), 
+  __raptor_fp *> get_id_from_raptor_fp (__raptor_fp *p) 
+{
+  return p;
+}
+
+template <typename CPP_TY>
+std::enable_if_t<
+  std::is_floating_point_v<CPP_TY> && sizeof(CPP_TY) == sizeof(uint32_t), 
+  uint32_t> get_id_from_raptor_fp (__raptor_fp *p) 
+{
+  return p->id.f;
+}
+
+template <typename CPP_TY>
+std::enable_if_t<
+  std::is_floating_point_v<CPP_TY> && sizeof(CPP_TY) == sizeof(uint16_t), 
+  uint16_t> get_id_from_raptor_fp (__raptor_fp *p) 
+{
+  return p->id.h;
+}
+
+template <typename CPP_TY>
+std::enable_if_t<
+  std::is_floating_point_v<CPP_TY> && sizeof(CPP_TY) == sizeof(uint32_t), 
+  uint32_t> raptor_fp_id_fp_to_uint (CPP_TY f) 
+{
+  // Enable if already ensures that the type size match, no need to check again
+  return raptor_bitcast<uint32_t>(f);
+}
+
+template <typename CPP_TY>
+std::enable_if_t<
+  std::is_floating_point_v<CPP_TY> && sizeof(CPP_TY) == sizeof(uint16_t), 
+  uint16_t> raptor_fp_id_fp_to_uint (CPP_TY h) 
+{
+  // Enable if already ensures that the type size match, no need to check again
+  return raptor_bitcast<uint16_t>(h);
+}
+
+#define RAPTOR_FLOAT_TYPE(CPP_TY, FROM_TY)                                     \
+  __RAPTOR_MPFR_DECL_ATTRIBUTES                                                \
+  __raptor_fp * get_##FROM_TY##_id_to_fp(size_t i);                            \
+  template <typename T>                                                        \
+  __raptor_fp * fp_##FROM_TY##_to_raptor_fp(T d) {                             \
+    if constexpr (sizeof(T) == sizeof(__raptor_fp *))                          \
+      return raptor_bitcast<__raptor_fp *>(d); /* type size already checked */ \
+    else                                                                       \
+      return get_##FROM_TY##_id_to_fp(raptor_fp_id_fp_to_uint(d));             \
+  }
+#include "raptor/FloatTypes.def"
+
 #define RAPTOR_FLOAT_TYPE(CPP_TY, FROM_TY)                                     \
   static inline CPP_TY __raptor_fprt_idx_to_##FROM_TY(uint64_t p) {            \
     return checked_raptor_bitcast<CPP_TY>(p);                                  \
@@ -81,10 +144,10 @@ template <typename To, typename From> To checked_raptor_bitcast(From from) {
     return checked_raptor_bitcast<uint64_t>(d);                                \
   }                                                                            \
   static inline CPP_TY __raptor_fprt_ptr_to_##FROM_TY(__raptor_fp *p) {        \
-    return checked_raptor_bitcast<CPP_TY>(p);                                  \
+    return checked_raptor_bitcast<CPP_TY>(get_id_from_raptor_fp<CPP_TY>(p));   \
   }                                                                            \
   static inline __raptor_fp *__raptor_fprt_##FROM_TY##_to_ptr(CPP_TY d) {      \
-    return checked_raptor_bitcast<__raptor_fp *>(d);                           \
+    return fp_##FROM_TY##_to_raptor_fp(d);                                     \
   }
 #include "raptor/FloatTypes.def"
 

--- a/runtime/include/private/raptor/Common.h
+++ b/runtime/include/private/raptor/Common.h
@@ -20,12 +20,6 @@
 extern std::atomic<long long> shadow_err_counter;
 extern std::atomic<bool> global_is_truncating;
 
-typedef union __raptor_fp_id {
-  size_t d;
-  uint32_t f;
-  uint16_t h;
-} __raptor_fp_id;
-
 typedef struct __raptor_op {
   const char *op;             // Operation name
   double l1_err = 0;          // Running error.
@@ -41,8 +35,12 @@ typedef struct __raptor_fp {
   // #ifdef RAPTOR_FPRT_ENABLE_SHADOW_RESIDUALS
   double excl_result;
   double shadow;
-  __raptor_fp_id id;
   // #endif
+  union ID {
+    size_t d;
+    uint32_t f;
+    uint16_t h;
+  } id;
 } __raptor_fp;
 
 static inline bool __raptor_fprt_is_mem_mode(int64_t mode) {
@@ -82,58 +80,11 @@ template <typename To, typename From> To checked_raptor_bitcast(From from) {
     abort();
 }
 
-template <typename CPP_TY>
-std::enable_if_t<
-  std::is_floating_point_v<CPP_TY> && sizeof(CPP_TY) == sizeof(__raptor_fp *), 
-  __raptor_fp *> get_id_from_raptor_fp (__raptor_fp *p) 
-{
-  return p;
-}
-
-template <typename CPP_TY>
-std::enable_if_t<
-  std::is_floating_point_v<CPP_TY> && sizeof(CPP_TY) == sizeof(uint32_t), 
-  uint32_t> get_id_from_raptor_fp (__raptor_fp *p) 
-{
-  return p->id.f;
-}
-
-template <typename CPP_TY>
-std::enable_if_t<
-  std::is_floating_point_v<CPP_TY> && sizeof(CPP_TY) == sizeof(uint16_t), 
-  uint16_t> get_id_from_raptor_fp (__raptor_fp *p) 
-{
-  return p->id.h;
-}
-
-template <typename CPP_TY>
-std::enable_if_t<
-  std::is_floating_point_v<CPP_TY> && sizeof(CPP_TY) == sizeof(uint32_t), 
-  uint32_t> raptor_fp_id_fp_to_uint (CPP_TY f) 
-{
-  // Enable if already ensures that the type size match, no need to check again
-  return raptor_bitcast<uint32_t>(f);
-}
-
-template <typename CPP_TY>
-std::enable_if_t<
-  std::is_floating_point_v<CPP_TY> && sizeof(CPP_TY) == sizeof(uint16_t), 
-  uint16_t> raptor_fp_id_fp_to_uint (CPP_TY h) 
-{
-  // Enable if already ensures that the type size match, no need to check again
-  return raptor_bitcast<uint16_t>(h);
-}
-
 #define RAPTOR_FLOAT_TYPE(CPP_TY, FROM_TY)                                     \
   __RAPTOR_MPFR_DECL_ATTRIBUTES                                                \
-  __raptor_fp * get_##FROM_TY##_id_to_fp(size_t i);                            \
-  template <typename T>                                                        \
-  __raptor_fp * fp_##FROM_TY##_to_raptor_fp(T d) {                             \
-    if constexpr (sizeof(T) == sizeof(__raptor_fp *))                          \
-      return raptor_bitcast<__raptor_fp *>(d); /* type size already checked */ \
-    else                                                                       \
-      return get_##FROM_TY##_id_to_fp(raptor_fp_id_fp_to_uint(d));             \
-  }
+  __raptor_fp * get_raptor_fp_from_##FROM_TY(CPP_TY d);                        \
+  __RAPTOR_MPFR_DECL_ATTRIBUTES                                                \
+  CPP_TY get_##FROM_TY##_from_raptor_fp(__raptor_fp *p);
 #include "raptor/FloatTypes.def"
 
 #define RAPTOR_FLOAT_TYPE(CPP_TY, FROM_TY)                                     \
@@ -144,10 +95,10 @@ std::enable_if_t<
     return checked_raptor_bitcast<uint64_t>(d);                                \
   }                                                                            \
   static inline CPP_TY __raptor_fprt_ptr_to_##FROM_TY(__raptor_fp *p) {        \
-    return checked_raptor_bitcast<CPP_TY>(get_id_from_raptor_fp<CPP_TY>(p));   \
+    return get_##FROM_TY##_from_raptor_fp(p);                                  \
   }                                                                            \
   static inline __raptor_fp *__raptor_fprt_##FROM_TY##_to_ptr(CPP_TY d) {      \
-    return fp_##FROM_TY##_to_raptor_fp(d);                                     \
+    return get_raptor_fp_from_##FROM_TY(d);                                    \
   }
 #include "raptor/FloatTypes.def"
 

--- a/runtime/include/private/raptor/Common.h
+++ b/runtime/include/private/raptor/Common.h
@@ -4,8 +4,6 @@
 #include <atomic>
 #include <cstdlib>
 #include <cstring>
-#include <type_traits>
-#include <vector>
 #include <mpfr.h>
 
 #define MAX_MPFR_OPERANDS 3

--- a/runtime/ir/Mpfr.cpp
+++ b/runtime/ir/Mpfr.cpp
@@ -135,8 +135,9 @@ void __raptor_fprt_trunc_change(int64_t is_push, int64_t to_e, int64_t to_m,
   __raptor_fp *__raptor_fprt_##FROM_TY##_to_ptr_checked(                       \
       CPP_TY d, int64_t exponent, int64_t significand, int64_t mode,           \
       const char *loc, mpfr_t *scratch) {                                      \
-    d = __raptor_fprt_##FROM_TY##_check_zero(d, exponent, significand, mode,   \
-                                             loc, scratch);                    \
+    if (__raptor_fprt_is_op_mode(mode))                                        \
+      d = __raptor_fprt_##FROM_TY##_check_zero(d, exponent, significand, mode, \
+                                               loc, scratch);                  \
     return __raptor_fprt_##FROM_TY##_to_ptr(d);                                \
   }                                                                            \
                                                                                \

--- a/runtime/ir/Mpfr.cpp
+++ b/runtime/ir/Mpfr.cpp
@@ -23,6 +23,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <map>
+#include <type_traits>
 #include <mpfr.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/runtime/ir/Mpfr.cpp
+++ b/runtime/ir/Mpfr.cpp
@@ -120,24 +120,26 @@ void __raptor_fprt_trunc_change(int64_t is_push, int64_t to_e, int64_t to_m,
   CPP_TY __raptor_fprt_##FROM_TY##_check_zero(                                 \
       CPP_TY _a, int64_t exponent, int64_t significand, int64_t mode,          \
       const char *loc, mpfr_t *scratch) {                                      \
-    if constexpr (sizeof(void *) == sizeof(CPP_TY)) {                          \
-      if (checked_raptor_bitcast<uint64_t>(_a) == 0)                           \
-        return __raptor_fprt_##FROM_TY##_const(0, exponent, significand, mode, \
-                                               loc, scratch);                  \
-      else                                                                     \
-        return _a;                                                             \
-    } else {                                                                   \
-      abort();                                                                 \
-    }                                                                          \
+    using fp_to_uint_t = std::enable_if_t<std::is_floating_point_v<CPP_TY> &&  \
+      (sizeof(CPP_TY) == sizeof(uint64_t) ||                                   \
+       sizeof(CPP_TY) == sizeof(uint32_t) ||                                   \
+       sizeof(CPP_TY) == sizeof(uint16_t)),                                    \
+      std::conditional_t<sizeof(CPP_TY) == sizeof(uint64_t), uint64_t,         \
+      std::conditional_t<sizeof(CPP_TY) == sizeof(uint32_t), uint32_t,         \
+      uint16_t>>>;                                                             \
+    if (checked_raptor_bitcast<fp_to_uint_t>(_a) == 0)                         \
+      return __raptor_fprt_##FROM_TY##_const(0, exponent, significand, mode,   \
+                                             loc, scratch);                    \
+    else                                                                       \
+      return _a;                                                               \
   }                                                                            \
                                                                                \
   __RAPTOR_MPFR_ATTRIBUTES                                                     \
   __raptor_fp *__raptor_fprt_##FROM_TY##_to_ptr_checked(                       \
       CPP_TY d, int64_t exponent, int64_t significand, int64_t mode,           \
       const char *loc, mpfr_t *scratch) {                                      \
-    if (__raptor_fprt_is_op_mode(mode))                                        \
-      d = __raptor_fprt_##FROM_TY##_check_zero(d, exponent, significand, mode, \
-                                               loc, scratch);                  \
+    d = __raptor_fprt_##FROM_TY##_check_zero(d, exponent, significand, mode,   \
+                                             loc, scratch);                    \
     return __raptor_fprt_##FROM_TY##_to_ptr(d);                                \
   }                                                                            \
                                                                                \

--- a/runtime/obj/GarbageCollection.cpp
+++ b/runtime/obj/GarbageCollection.cpp
@@ -57,6 +57,17 @@ struct {
 } __raptor_mpfr_fps;
 
 #define RAPTOR_FLOAT_TYPE(CPP_TY, FROM_TY)                                     \
+  std::vector<__raptor_fp *> __raptor_mpfr_##FROM_TY##_id_to_fp;               \
+  std::vector<size_t> __raptor_mpfr_##FROM_TY##_free_id;
+#include "raptor/FloatTypes.def"
+
+#define RAPTOR_FLOAT_TYPE(CPP_TY, FROM_TY)                                     \
+  inline __raptor_fp * get_##FROM_TY##_id_to_fp(size_t i) {                    \
+    return __raptor_mpfr_##FROM_TY##_id_to_fp.at(i);                           \
+  }
+#include "raptor/FloatTypes.def"
+
+#define RAPTOR_FLOAT_TYPE(CPP_TY, FROM_TY)                                     \
   __RAPTOR_MPFR_ATTRIBUTES                                                     \
   CPP_TY __raptor_fprt_##FROM_TY##_get(CPP_TY _a, int64_t exponent,            \
                                        int64_t significand, int64_t mode,      \
@@ -75,6 +86,16 @@ struct {
     mpfr_set_d(a->result, _a, __RAPTOR_MPFR_DEFAULT_ROUNDING_MODE);            \
     a->excl_result = _a;                                                       \
     a->shadow = _a;                                                            \
+    if constexpr (sizeof(CPP_TY) != sizeof(__raptor_fp *)) {                   \
+      if (__raptor_mpfr_##FROM_TY##_free_id.empty()) {                         \
+        a->id.d = __raptor_mpfr_##FROM_TY##_id_to_fp.size();                   \
+        __raptor_mpfr_##FROM_TY##_id_to_fp.push_back(a);                       \
+      } else {                                                                 \
+        a->id.d = __raptor_mpfr_##FROM_TY##_free_id.back();                    \
+        __raptor_mpfr_##FROM_TY##_free_id.pop_back();                          \
+        __raptor_mpfr_##FROM_TY##_id_to_fp.at(a->id.d) = a;                    \
+      }                                                                        \
+    }                                                                          \
     return __raptor_fprt_ptr_to_##FROM_TY(a);                                  \
   }                                                                            \
                                                                                \
@@ -94,6 +115,16 @@ struct {
       void *scratch) {                                                         \
     __raptor_mpfr_fps.all.push_back({});                                       \
     __raptor_fp *a = &__raptor_mpfr_fps.all.back().fp;                         \
+    if constexpr (sizeof(CPP_TY) != sizeof(__raptor_fp *)) {                   \
+      if (__raptor_mpfr_##FROM_TY##_free_id.empty()) {                         \
+        a->id.d = __raptor_mpfr_##FROM_TY##_id_to_fp.size();                   \
+        __raptor_mpfr_##FROM_TY##_id_to_fp.push_back(a);                       \
+      } else {                                                                 \
+        a->id.d = __raptor_mpfr_##FROM_TY##_free_id.back();                    \
+        __raptor_mpfr_##FROM_TY##_free_id.pop_back();                          \
+        __raptor_mpfr_##FROM_TY##_id_to_fp.at(a->id.d) = a;                    \
+      }                                                                        \
+    }                                                                          \
     mpfr_init2(a->result, significand + 1); /* see MPFR_FP_EMULATION */        \
     return a;                                                                  \
   }                                                                            \

--- a/runtime/obj/GarbageCollection.cpp
+++ b/runtime/obj/GarbageCollection.cpp
@@ -31,6 +31,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>
+#include <limits>
 #include <list>
 #include <mpfr.h>
 #include <stdint.h>
@@ -44,11 +45,106 @@
 
 bool excl_trunc = false;
 
+namespace gcfloatidmap {
+  /* Define types for index to __raptor_fp * mappings */
+  using id_to_fp_t = std::vector<__raptor_fp *>; // Find __raptor_fp * with id
+  using free_id_t = std::vector<size_t>; // Pool of free id that can be reused
+  // Contains pointers to the id to __raptor_fp * mapping and pool of free ids
+  struct id_map_info { id_to_fp_t * id_to_fp; free_id_t * free_id; };
+
+  /* Define type constraints to enable compile time checks */
+  // Constraints for type T that do not use id map (address is used as id)
+  template <typename T>
+  using valid_no_id_t = std::enable_if_t<
+    std::is_floating_point_v<T> && // Is native floating point type
+    // Not dealing floating point sizes larger than pointer size for now
+    (sizeof(T) == sizeof(__raptor_fp *)), bool>;
+  // Constraints for type T that uses id map
+  template <typename T>
+  using valid_use_id_t = std::enable_if_t<
+    std::is_floating_point_v<T> && // Is native floating point type
+    // Floating point size is smaller than pointer size
+    (sizeof(T) < sizeof(__raptor_fp *)) && 
+    // Sanity check: should be 32- or 16-bit
+    (sizeof(T) == sizeof(uint32_t) || sizeof(T) == sizeof(uint16_t)), bool>;
+  // Corresponding unsigned int type used for indexing for type T that uses id
+  template <typename T, valid_use_id_t<T> = true>
+  using fp_to_uint_t = std::enable_if_t<
+    // Sanity check: as of C++23, the smallest native fp types size is 16 bits
+    (sizeof(T) >= sizeof(uint16_t)),
+    // size_t is only guaranteed to be at least 16-bit wide per C/C++ standard
+    std::conditional_t<sizeof(T) == sizeof(size_t), size_t,
+    std::conditional_t<sizeof(T) == sizeof(uint32_t), uint32_t,
+    uint16_t>>>;
+  // Constraints for type T that uses id with corresponding index type U
+  template <typename T, typename U>
+  using use_id_t = std::enable_if_t<std::is_same_v<fp_to_uint_t<T>, U>, bool>;
+
+  /* Functions to get index to __raptor_fp * mapping structures */
+  // Get the index to __raptor_fp * mapping structure with no type constraint
+  template <typename T> id_map_info _get_id_map_info();
+  // Get the index to __raptor_fp * mapping structure of type T that uses id
+  template <typename T, valid_use_id_t<T> = true>
+  inline id_map_info get_id_map_info() { return _get_id_map_info<T>(); }
+
+  /* Functions to find __raptor_fp * given index and vice versa */
+  // Convert f of type T that do not use id to __raptor_fp *
+  template <typename T, valid_no_id_t<T> = true> 
+  inline __raptor_fp * get_p_from_f(T f) {
+    return raptor_bitcast<__raptor_fp *>(f);
+  }
+  // Get the __raptor_fp * corresponting to id f of type T that uses id 
+  template <typename T, valid_use_id_t<T> = true> 
+  inline __raptor_fp * get_p_from_f(T f) {
+    return get_id_map_info<T>().id_to_fp->at(
+      raptor_bitcast<fp_to_uint_t<T>>(f)); 
+  }
+  // Convert __raptor_fp * p to type T that do not use id
+  template <typename T, valid_no_id_t<T> = true> 
+  inline T get_f_from_p (__raptor_fp *p) { return raptor_bitcast<T>(p); }
+  // Get the id converted to type T that uses 32-bit id from __raptor_fp * p
+  template <typename T, use_id_t<T, uint32_t> = true>
+  inline T get_f_from_p (__raptor_fp *p) { return raptor_bitcast<T>(p->id.f); }
+  // Get the id converted to type T that uses 16-bit id from __raptor_fp * p
+  template <typename T, use_id_t<T, uint16_t> = true>
+  inline T get_f_from_p (__raptor_fp *p) { return raptor_bitcast<T>(p->id.h); }
+
+  /* Functions to add/remove __raptor_fp * to/from the mapping structure */
+  // Add __raptor_fp * to the mapping structure m and assign id
+  template <typename T, valid_use_id_t<T> = true> 
+  void add_fp(id_map_info & m, __raptor_fp * p) {
+    m = get_id_map_info<T>(); // Set the pointers to the mapping structure
+    if (m.free_id->empty()) { // Get new id if free pool is empty
+      p->id.d = m.id_to_fp->size();
+      m.id_to_fp->push_back(p); // Add mapping of new id to p
+    } else { // Use available free id if the pool is not empty
+      p->id.d = m.free_id->back(); // Get a free id
+      m.free_id->pop_back(); // Remove it from the free pool
+      m.id_to_fp->at(p->id.d) = p; // Add mapping of free id to p
+    }
+  }
+  // Remove __raptor_fp * mapped to id from the index mapping structure m
+  void remove_fp(id_map_info & m, __raptor_fp::ID &id) {
+    if (m.id_to_fp) { // If mapping structures are used
+      m.free_id->push_back(id.d); // Add id to pool of free ids
+      m.id_to_fp->at(id.d) = nullptr; // Unregister fp from id_to_fp mapping
+    }
+  }
+};
+
 struct GCFloatTy {
   __raptor_fp fp;
   bool seen;
+  // Record where the fp is added to remove it when destructing
+  gcfloatidmap::id_map_info id_map = {nullptr, nullptr};
   GCFloatTy() : seen(false) {}
-  ~GCFloatTy() {}
+  ~GCFloatTy() { gcfloatidmap::remove_fp(id_map, fp.id); }
+  // Set id_map that the fp is added to and assign fp.id if T uses id
+  template <typename T, gcfloatidmap::valid_use_id_t<T> = true>
+  void set_raptor_fp_id() { gcfloatidmap::add_fp<T>(id_map, &fp); }
+  // Do nothing if T does not use id
+  template <typename T, gcfloatidmap::valid_no_id_t<T> = true>
+  void set_raptor_fp_id() {}
 };
 struct {
   std::list<GCFloatTy> all;
@@ -56,78 +152,31 @@ struct {
 
 } __raptor_mpfr_fps;
 
+template <typename T>
+gcfloatidmap::id_map_info gcfloatidmap::_get_id_map_info() {
+  // To provide compile time error message if it get misused
+  static_assert(false, "Specialization for type T not implemented.");
+  return id_map_info{}; // return to avoid compile time warning
+}
+
 // __raptor_mpfr_##FROM_TY##_id_to_fp vectors need to skip the first element
 // because id == 0 is special case for __raptor_fprt_##FROM_TY##_check_zero
 #define RAPTOR_FLOAT_TYPE(CPP_TY, FROM_TY)                                     \
-  std::vector<__raptor_fp *> __raptor_mpfr_##FROM_TY##_id_to_fp(1);            \
-  std::vector<size_t> __raptor_mpfr_##FROM_TY##_free_id;
-#include "raptor/FloatTypes.def"
-
-template <typename CPP_TY>
-inline std::enable_if_t<
-  std::is_floating_point_v<CPP_TY> && sizeof(CPP_TY) == sizeof(uint32_t), 
-  uint32_t> raptor_fp_id_fp_to_uint (CPP_TY f) 
-{
-  // Enable if already ensures that the type size match, no need to check again
-  return raptor_bitcast<uint32_t>(f);
-}
-
-template <typename CPP_TY>
-inline std::enable_if_t<
-  std::is_floating_point_v<CPP_TY> && sizeof(CPP_TY) == sizeof(uint16_t), 
-  uint16_t> raptor_fp_id_fp_to_uint (CPP_TY h) 
-{
-  // Enable if already ensures that the type size match, no need to check again
-  return raptor_bitcast<uint16_t>(h);
-}
-
-
-template <typename CPP_TY>
-inline std::enable_if_t<
-  std::is_floating_point_v<CPP_TY> && sizeof(CPP_TY) == sizeof(__raptor_fp *), 
-  CPP_TY> get_id_from_raptor_fp (__raptor_fp *p) 
-{
-  // Enable if already ensures that the type size match, no need to check again
-  return raptor_bitcast<CPP_TY>(p);
-}
-
-template <typename CPP_TY>
-inline std::enable_if_t<
-  std::is_floating_point_v<CPP_TY> && sizeof(CPP_TY) == sizeof(uint32_t), 
-  CPP_TY> get_id_from_raptor_fp (__raptor_fp *p) 
-{
-  // Enable if already ensures that the type size match, no need to check again
-  return raptor_bitcast<CPP_TY>(p->id.f);
-}
-
-template <typename CPP_TY>
-inline std::enable_if_t<
-  std::is_floating_point_v<CPP_TY> && sizeof(CPP_TY) == sizeof(uint16_t), 
-  CPP_TY> get_id_from_raptor_fp (__raptor_fp *p) 
-{
-  // Enable if already ensures that the type size match, no need to check again
-  return raptor_bitcast<CPP_TY>(p->id.h);
-}
-
-#define RAPTOR_FLOAT_TYPE(CPP_TY, FROM_TY)                                     \
-  template <typename T>                                                        \
-  inline __raptor_fp * get_raptor_fp_from_##FROM_TY##_(T d) {                  \
-    if constexpr (sizeof(T) == sizeof(__raptor_fp *))                          \
-      return raptor_bitcast<__raptor_fp *>(d); /* type size already checked */ \
-    else                                                                       \
-      return __raptor_mpfr_##FROM_TY##_id_to_fp.at(raptor_fp_id_fp_to_uint(d));\
+  gcfloatidmap::id_to_fp_t __raptor_mpfr_##FROM_TY##_id_to_fp(1);              \
+  gcfloatidmap::free_id_t __raptor_mpfr_##FROM_TY##_free_id;                   \
+  template <>                                                                  \
+  gcfloatidmap::id_map_info gcfloatidmap::_get_id_map_info<CPP_TY>() {         \
+    return id_map_info{ &__raptor_mpfr_##FROM_TY##_id_to_fp,                   \
+      &__raptor_mpfr_##FROM_TY##_free_id };                                    \
   }                                                                            \
   __RAPTOR_MPFR_ATTRIBUTES                                                     \
   __raptor_fp * get_raptor_fp_from_##FROM_TY(CPP_TY d) {                       \
-    return get_raptor_fp_from_##FROM_TY##_(d);                                 \
+    return gcfloatidmap::get_p_from_f(d);                                      \
   }                                                                            \
   __RAPTOR_MPFR_ATTRIBUTES                                                     \
   CPP_TY get_##FROM_TY##_from_raptor_fp(__raptor_fp *p) {                      \
-    return get_id_from_raptor_fp<CPP_TY>(p);                                   \
-  }
-#include "raptor/FloatTypes.def"
-
-#define RAPTOR_FLOAT_TYPE(CPP_TY, FROM_TY)                                     \
+    return gcfloatidmap::get_f_from_p<CPP_TY>(p);                              \
+  }                                                                            \
   __RAPTOR_MPFR_ATTRIBUTES                                                     \
   CPP_TY __raptor_fprt_##FROM_TY##_get(CPP_TY _a, int64_t exponent,            \
                                        int64_t significand, int64_t mode,      \
@@ -141,21 +190,12 @@ inline std::enable_if_t<
                                        int64_t significand, int64_t mode,      \
                                        const char *loc, void *scratch) {       \
     __raptor_mpfr_fps.all.push_back({});                                       \
+    __raptor_mpfr_fps.all.back().set_raptor_fp_id<CPP_TY>();                   \
     __raptor_fp *a = &__raptor_mpfr_fps.all.back().fp;                         \
     mpfr_init2(a->result, significand + 1); /* see MPFR_FP_EMULATION */        \
     mpfr_set_d(a->result, _a, __RAPTOR_MPFR_DEFAULT_ROUNDING_MODE);            \
     a->excl_result = _a;                                                       \
     a->shadow = _a;                                                            \
-    if constexpr (sizeof(CPP_TY) != sizeof(__raptor_fp *)) {                   \
-      if (__raptor_mpfr_##FROM_TY##_free_id.empty()) {                         \
-        a->id.d = __raptor_mpfr_##FROM_TY##_id_to_fp.size();                   \
-        __raptor_mpfr_##FROM_TY##_id_to_fp.push_back(a);                       \
-      } else {                                                                 \
-        a->id.d = __raptor_mpfr_##FROM_TY##_free_id.back();                    \
-        __raptor_mpfr_##FROM_TY##_free_id.pop_back();                          \
-        __raptor_mpfr_##FROM_TY##_id_to_fp.at(a->id.d) = a;                    \
-      }                                                                        \
-    }                                                                          \
     return __raptor_fprt_ptr_to_##FROM_TY(a);                                  \
   }                                                                            \
                                                                                \
@@ -174,17 +214,8 @@ inline std::enable_if_t<
       int64_t exponent, int64_t significand, int64_t mode, const char *loc,    \
       void *scratch) {                                                         \
     __raptor_mpfr_fps.all.push_back({});                                       \
+    __raptor_mpfr_fps.all.back().set_raptor_fp_id<CPP_TY>();                   \
     __raptor_fp *a = &__raptor_mpfr_fps.all.back().fp;                         \
-    if constexpr (sizeof(CPP_TY) != sizeof(__raptor_fp *)) {                   \
-      if (__raptor_mpfr_##FROM_TY##_free_id.empty()) {                         \
-        a->id.d = __raptor_mpfr_##FROM_TY##_id_to_fp.size();                   \
-        __raptor_mpfr_##FROM_TY##_id_to_fp.push_back(a);                       \
-      } else {                                                                 \
-        a->id.d = __raptor_mpfr_##FROM_TY##_free_id.back();                    \
-        __raptor_mpfr_##FROM_TY##_free_id.pop_back();                          \
-        __raptor_mpfr_##FROM_TY##_id_to_fp.at(a->id.d) = a;                    \
-      }                                                                        \
-    }                                                                          \
     mpfr_init2(a->result, significand + 1); /* see MPFR_FP_EMULATION */        \
     return a;                                                                  \
   }                                                                            \

--- a/runtime/obj/GarbageCollection.cpp
+++ b/runtime/obj/GarbageCollection.cpp
@@ -108,6 +108,18 @@ namespace gcfloatidmap {
   // Get the id converted to type T that uses 16-bit id from __raptor_fp * p
   template <typename T, use_id_t<T, uint16_t> = true>
   inline T get_f_from_p (__raptor_fp *p) { return raptor_bitcast<T>(p->id.h); }
+  // Check and abort if id cannot be stored in type T
+  template <typename T, valid_use_id_t<T> = true> 
+  void check_id_overflow(__raptor_fp::ID &id) {
+    using num_bits = std::integral_constant<unsigned, 
+      sizeof(T) * std::numeric_limits<unsigned char>::digits>;
+    if (id.d >= std::numeric_limits<fp_to_uint_t<T>>::max()) {
+      std::cerr << "Exceeding maximum number of " << (num_bits::value);
+      std::cerr << "-bit floating point values truncation in mem-mode.";
+      std::cerr << std::endl;
+      abort();
+    }
+  }
 
   /* Functions to add/remove __raptor_fp * to/from the mapping structure */
   // Add __raptor_fp * to the mapping structure m and assign id
@@ -116,6 +128,7 @@ namespace gcfloatidmap {
     m = get_id_map_info<T>(); // Set the pointers to the mapping structure
     if (m.free_id->empty()) { // Get new id if free pool is empty
       p->id.d = m.id_to_fp->size();
+      check_id_overflow<T>(p->id); // Check new id can be stored in type T
       m.id_to_fp->push_back(p); // Add mapping of new id to p
     } else { // Use available free id if the pool is not empty
       p->id.d = m.free_id->back(); // Get a free id

--- a/runtime/obj/GarbageCollection.cpp
+++ b/runtime/obj/GarbageCollection.cpp
@@ -248,11 +248,11 @@ struct GCFloatTy {
   void set_raptor_fp_id() {}
 };
 struct {
-  std::list<GCFloatTy> all;
   #define RAPTOR_FLOAT_TYPE(CPP_TY, FROM_TY) , CPP_TY
   gcfloatidmap::id_maps_t<0
     #include "raptor/FloatTypes.def"
   > id_maps;
+  std::list<GCFloatTy> all;
   void clear() { all.clear(); id_maps.clear(); }
 
 } __raptor_mpfr_fps;

--- a/runtime/obj/GarbageCollection.cpp
+++ b/runtime/obj/GarbageCollection.cpp
@@ -48,12 +48,6 @@
 bool excl_trunc = false;
 
 namespace gcfloatidmap {
-  /* Define types for index to __raptor_fp * mappings */
-  using id_to_fp_t = std::vector<__raptor_fp *>; // Find __raptor_fp * with id
-  using free_id_t = std::vector<size_t>; // Pool of free id that can be reused
-  // Contains pointers to the id to __raptor_fp * mapping and pool of free ids
-  struct id_map_info { id_to_fp_t * id_to_fp; free_id_t * free_id; };
-
   /* Define type constraints to enable compile time checks */
   // Constraints for type T that do not use id map (address is used as id)
   template <typename T>
@@ -82,16 +76,100 @@ namespace gcfloatidmap {
   template <typename T, typename U>
   using use_id_t = std::enable_if_t<std::is_same_v<fp_to_uint_t<T>, U>, bool>;
 
+  /* Define types that help to calculate compile-time constants */
+  // Whether type T uses id, default with value false
+  template<typename T, typename U = bool> 
+  struct is_use_id_t : std::false_type {};
+  // Has value true if type T uses id
+  template<typename T>
+  struct is_use_id_t<T, valid_use_id_t<T>> : std::true_type {};
+  // Get the index of type U that uses id among types that uses id in T...
+  template<typename U, unsigned I, bool B, typename ...T>
+  struct get_index {};
+  // U is not found, check if it is next type V, increment I only if V uses id
+  template<typename U, unsigned I, typename V, typename ...T>
+  struct get_index<U, I, false, V, T...> : get_index<U, I + std::conditional_t<
+    is_use_id_t<V>::value, std::integral_constant<unsigned, 1>,
+    std::integral_constant<unsigned, 0>>::value, std::is_same_v<U,V>, T...> {};
+  // U is found, stop searching, get_index has member value with index I - 1
+  template<typename U, unsigned I, typename ...T>
+  struct get_index<U, I, true, T...> : std::enable_if_t<is_use_id_t<U>::value, 
+    std::integral_constant<unsigned, I - 1>> {};
+  // Get the index of a type that uses id among types that uses id in a list
+  template<typename U, typename V, typename ...T>
+  using get_id = get_index<U, std::conditional_t<is_use_id_t<V>::value, 
+    std::integral_constant<unsigned, 1>,
+    std::integral_constant<unsigned, 0>>::value, std::is_same_v<U, V>, T...>;
+
+  /* Define types for index to __raptor_fp * mappings */
+  using id_to_fp_t = std::vector<__raptor_fp *>; // Find __raptor_fp * with id
+  using free_id_t = std::vector<size_t>; // Pool of free id that can be reused
+  // Contains pointers to the id to __raptor_fp * mapping and pool of free ids
+  struct id_map_info { id_to_fp_t * id_to_fp; free_id_t * free_id; };
+  // Contains the index to __raptor_fp * mapping structures
+  template<typename T, valid_use_id_t<T> = true> 
+  struct id_map_t : id_map_info { 
+    // id_to_fp are created with a dummy first element
+    // because id == 0 is special case for __raptor_fprt_##FROM_TY##_check_zero
+    id_to_fp_t id_to_fp{nullptr}; free_id_t free_id; 
+    id_map_t() {
+      id_map_info::id_to_fp = &id_to_fp;
+      id_map_info::free_id = &free_id;
+    }
+  };
+  // Create id_map and add to id_map_infos for each type that uses id in T...
+  template<unsigned I, bool B, typename ...T>
+  struct add_id_maps { 
+    std::vector<id_map_info *> id_map_infos;
+    using num_id_maps = std::integral_constant<size_t, I>;
+    add_id_maps() { id_map_infos.resize(I, nullptr); }
+    ~add_id_maps() { id_map_infos.clear(); } 
+  };
+  // Construct new id_map for type U that uses id
+  template<unsigned I, typename U>
+  struct add_id_maps<I, true, U> : add_id_maps<I+1, false> {
+    using add_id_maps<I+1, false>::id_map_infos;
+    add_id_maps<I, true, U>() { id_map_infos[I] = new id_map_t<U>(); }
+    ~add_id_maps<I, true, U>() { delete id_map_infos[I]; }
+  };
+  // Construct new id_map for type U that uses id and continue with next type V
+  template<unsigned I, typename U, typename V, typename ...T>
+  struct add_id_maps<I, true, U, V, T...> : 
+    add_id_maps<I + 1, is_use_id_t<V>::value, V, T...> {
+    using add_id_maps<I + 1, is_use_id_t<V>::value, V, T...>::id_map_infos;
+    add_id_maps<I, true, U, V, T...>() { id_map_infos[I] = new id_map_t<U>(); }
+    ~add_id_maps<I, true, U, V, T...>() { delete id_map_infos[I]; }
+  };
+  // Do nothing for type U that does not use id and continue with next type V
+  template<unsigned I, typename U, typename V, typename ...T>
+  struct add_id_maps<I, false, U, V, T...> : 
+    add_id_maps<I, is_use_id_t<V>::value, V, T...> {};
+  // id_maps for types that uses id among U and T... with starting index I
+  template<unsigned I, typename U, typename ...T>
+  struct id_maps_t {};
+  // id_maps for types that uses id among U and T...
+  template<typename U, typename ...T>
+  struct id_maps_t<0, U, T...> : add_id_maps<0, is_use_id_t<U>::value, U, T...>
+  {
+    using add_id_maps<0, is_use_id_t<U>::value, U, T...>::id_map_infos;
+    using typename add_id_maps<0, is_use_id_t<U>::value, U, T...>::num_id_maps;
+    template<typename V, valid_use_id_t<V> = true>
+    const id_map_info& get_info() {
+      static_assert(get_id<V, U, T...>::value < num_id_maps::value);
+      return *id_map_infos[get_id<V, U, T...>::value];
+    }
+    void clear() {
+      for (auto info : id_map_infos) {
+        info->id_to_fp->clear(); info->id_to_fp->resize(1, nullptr);
+        info->free_id->clear();
+      }
+    }
+  };
+
   /* Functions to get index to __raptor_fp * mapping structures */
-  // Get the index to __raptor_fp * mapping structure with no type constraint
-  template <typename T> id_map_info _get_id_map_info() {
-    // To provide compile time error message if it get misused
-    static_assert(false, "Specialization for type T not implemented.");
-    return {nullptr, nullptr}; // return to avoid compile time warning
-  }
   // Get the index to __raptor_fp * mapping structure of type T that uses id
   template <typename T, valid_use_id_t<T> = true>
-  inline id_map_info get_id_map_info() { return _get_id_map_info<T>(); }
+  inline id_map_info get_id_map_info();
 
   /* Functions to find __raptor_fp * given index and vice versa */
   // Convert f of type T that do not use id to __raptor_fp *
@@ -171,22 +249,21 @@ struct GCFloatTy {
 };
 struct {
   std::list<GCFloatTy> all;
-  // id_to_fp_##FROM_TY vectors are created with a dummy first pointer
-  // because id == 0 is special case for __raptor_fprt_##FROM_TY##_check_zero
-  #define RAPTOR_FLOAT_TYPE(CPP_TY, FROM_TY)                                   \
-    gcfloatidmap::id_to_fp_t id_to_fp_##FROM_TY{nullptr};                      \
-    gcfloatidmap::free_id_t free_id_##FROM_TY; 
-  #include "raptor/FloatTypes.def"
-  void clear() { all.clear(); }
+  #define RAPTOR_FLOAT_TYPE(CPP_TY, FROM_TY) , CPP_TY
+  gcfloatidmap::id_maps_t<0
+    #include "raptor/FloatTypes.def"
+  > id_maps;
+  void clear() { all.clear(); id_maps.clear(); }
 
 } __raptor_mpfr_fps;
 
+template <typename T, gcfloatidmap::valid_use_id_t<T>>
+inline gcfloatidmap::id_map_info gcfloatidmap::get_id_map_info() {
+  return __raptor_mpfr_fps.id_maps.get_info<T>();
+}
+
+
 #define RAPTOR_FLOAT_TYPE(CPP_TY, FROM_TY)                                     \
-  template <>                                                                  \
-  gcfloatidmap::id_map_info gcfloatidmap::_get_id_map_info<CPP_TY>() {         \
-    return { &__raptor_mpfr_fps.id_to_fp_##FROM_TY,                            \
-      &__raptor_mpfr_fps.free_id_##FROM_TY };                                  \
-  }                                                                            \
   __RAPTOR_MPFR_ATTRIBUTES                                                     \
   __raptor_fp * get_raptor_fp_from_##FROM_TY(CPP_TY d) {                       \
     return gcfloatidmap::get_p_from_f(d);                                      \

--- a/runtime/obj/GarbageCollection.cpp
+++ b/runtime/obj/GarbageCollection.cpp
@@ -63,9 +63,67 @@ struct {
   std::vector<size_t> __raptor_mpfr_##FROM_TY##_free_id;
 #include "raptor/FloatTypes.def"
 
+template <typename CPP_TY>
+inline std::enable_if_t<
+  std::is_floating_point_v<CPP_TY> && sizeof(CPP_TY) == sizeof(uint32_t), 
+  uint32_t> raptor_fp_id_fp_to_uint (CPP_TY f) 
+{
+  // Enable if already ensures that the type size match, no need to check again
+  return raptor_bitcast<uint32_t>(f);
+}
+
+template <typename CPP_TY>
+inline std::enable_if_t<
+  std::is_floating_point_v<CPP_TY> && sizeof(CPP_TY) == sizeof(uint16_t), 
+  uint16_t> raptor_fp_id_fp_to_uint (CPP_TY h) 
+{
+  // Enable if already ensures that the type size match, no need to check again
+  return raptor_bitcast<uint16_t>(h);
+}
+
+
+template <typename CPP_TY>
+inline std::enable_if_t<
+  std::is_floating_point_v<CPP_TY> && sizeof(CPP_TY) == sizeof(__raptor_fp *), 
+  CPP_TY> get_id_from_raptor_fp (__raptor_fp *p) 
+{
+  // Enable if already ensures that the type size match, no need to check again
+  return raptor_bitcast<CPP_TY>(p);
+}
+
+template <typename CPP_TY>
+inline std::enable_if_t<
+  std::is_floating_point_v<CPP_TY> && sizeof(CPP_TY) == sizeof(uint32_t), 
+  CPP_TY> get_id_from_raptor_fp (__raptor_fp *p) 
+{
+  // Enable if already ensures that the type size match, no need to check again
+  return raptor_bitcast<CPP_TY>(p->id.f);
+}
+
+template <typename CPP_TY>
+inline std::enable_if_t<
+  std::is_floating_point_v<CPP_TY> && sizeof(CPP_TY) == sizeof(uint16_t), 
+  CPP_TY> get_id_from_raptor_fp (__raptor_fp *p) 
+{
+  // Enable if already ensures that the type size match, no need to check again
+  return raptor_bitcast<CPP_TY>(p->id.h);
+}
+
 #define RAPTOR_FLOAT_TYPE(CPP_TY, FROM_TY)                                     \
-  inline __raptor_fp * get_##FROM_TY##_id_to_fp(size_t i) {                    \
-    return __raptor_mpfr_##FROM_TY##_id_to_fp.at(i);                           \
+  template <typename T>                                                        \
+  inline __raptor_fp * get_raptor_fp_from_##FROM_TY##_(T d) {                  \
+    if constexpr (sizeof(T) == sizeof(__raptor_fp *))                          \
+      return raptor_bitcast<__raptor_fp *>(d); /* type size already checked */ \
+    else                                                                       \
+      return __raptor_mpfr_##FROM_TY##_id_to_fp.at(raptor_fp_id_fp_to_uint(d));\
+  }                                                                            \
+  __RAPTOR_MPFR_ATTRIBUTES                                                     \
+  __raptor_fp * get_raptor_fp_from_##FROM_TY(CPP_TY d) {                       \
+    return get_raptor_fp_from_##FROM_TY##_(d);                                 \
+  }                                                                            \
+  __RAPTOR_MPFR_ATTRIBUTES                                                     \
+  CPP_TY get_##FROM_TY##_from_raptor_fp(__raptor_fp *p) {                      \
+    return get_id_from_raptor_fp<CPP_TY>(p);                                   \
   }
 #include "raptor/FloatTypes.def"
 

--- a/runtime/obj/GarbageCollection.cpp
+++ b/runtime/obj/GarbageCollection.cpp
@@ -84,7 +84,11 @@ namespace gcfloatidmap {
 
   /* Functions to get index to __raptor_fp * mapping structures */
   // Get the index to __raptor_fp * mapping structure with no type constraint
-  template <typename T> id_map_info _get_id_map_info();
+  template <typename T> id_map_info _get_id_map_info() {
+    // To provide compile time error message if it get misused
+    static_assert(false, "Specialization for type T not implemented.");
+    return {nullptr, nullptr}; // return to avoid compile time warning
+  }
   // Get the index to __raptor_fp * mapping structure of type T that uses id
   template <typename T, valid_use_id_t<T> = true>
   inline id_map_info get_id_map_info() { return _get_id_map_info<T>(); }
@@ -167,26 +171,21 @@ struct GCFloatTy {
 };
 struct {
   std::list<GCFloatTy> all;
+  // id_to_fp_##FROM_TY vectors are created with a dummy first pointer
+  // because id == 0 is special case for __raptor_fprt_##FROM_TY##_check_zero
+  #define RAPTOR_FLOAT_TYPE(CPP_TY, FROM_TY)                                   \
+    gcfloatidmap::id_to_fp_t id_to_fp_##FROM_TY{nullptr};                      \
+    gcfloatidmap::free_id_t free_id_##FROM_TY; 
+  #include "raptor/FloatTypes.def"
   void clear() { all.clear(); }
 
 } __raptor_mpfr_fps;
 
-template <typename T>
-gcfloatidmap::id_map_info gcfloatidmap::_get_id_map_info() {
-  // To provide compile time error message if it get misused
-  static_assert(false, "Specialization for type T not implemented.");
-  return id_map_info{}; // return to avoid compile time warning
-}
-
-// __raptor_mpfr_##FROM_TY##_id_to_fp vectors need to skip the first element
-// because id == 0 is special case for __raptor_fprt_##FROM_TY##_check_zero
 #define RAPTOR_FLOAT_TYPE(CPP_TY, FROM_TY)                                     \
-  gcfloatidmap::id_to_fp_t __raptor_mpfr_##FROM_TY##_id_to_fp(1);              \
-  gcfloatidmap::free_id_t __raptor_mpfr_##FROM_TY##_free_id;                   \
   template <>                                                                  \
   gcfloatidmap::id_map_info gcfloatidmap::_get_id_map_info<CPP_TY>() {         \
-    return id_map_info{ &__raptor_mpfr_##FROM_TY##_id_to_fp,                   \
-      &__raptor_mpfr_##FROM_TY##_free_id };                                    \
+    return { &__raptor_mpfr_fps.id_to_fp_##FROM_TY,                            \
+      &__raptor_mpfr_fps.free_id_##FROM_TY };                                  \
   }                                                                            \
   __RAPTOR_MPFR_ATTRIBUTES                                                     \
   __raptor_fp * get_raptor_fp_from_##FROM_TY(CPP_TY d) {                       \
@@ -282,6 +281,7 @@ void raptor_fprt_gc_doit() {
     }
   }
   raptor_fprt_gc_clear_seen();
+  // TODO: resize id mapping structures if many are erased?
 }
 
 __RAPTOR_MPFR_ATTRIBUTES

--- a/runtime/obj/GarbageCollection.cpp
+++ b/runtime/obj/GarbageCollection.cpp
@@ -33,6 +33,8 @@
 #include <iostream>
 #include <limits>
 #include <list>
+#include <type_traits>
+#include <vector>
 #include <mpfr.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/runtime/obj/GarbageCollection.cpp
+++ b/runtime/obj/GarbageCollection.cpp
@@ -56,8 +56,10 @@ struct {
 
 } __raptor_mpfr_fps;
 
+// __raptor_mpfr_##FROM_TY##_id_to_fp vectors need to skip the first element
+// because id == 0 is special case for __raptor_fprt_##FROM_TY##_check_zero
 #define RAPTOR_FLOAT_TYPE(CPP_TY, FROM_TY)                                     \
-  std::vector<__raptor_fp *> __raptor_mpfr_##FROM_TY##_id_to_fp;               \
+  std::vector<__raptor_fp *> __raptor_mpfr_##FROM_TY##_id_to_fp(1);            \
   std::vector<size_t> __raptor_mpfr_##FROM_TY##_free_id;
 #include "raptor/FloatTypes.def"
 

--- a/runtime/obj/GarbageCollection.cpp
+++ b/runtime/obj/GarbageCollection.cpp
@@ -146,11 +146,8 @@ namespace gcfloatidmap {
     add_id_maps<I, is_use_id_t<V>::value, V, T...> {};
   // id_maps for types that uses id among U and T... with starting index I
   template<unsigned I, typename U, typename ...T>
-  struct id_maps_t {};
-  // id_maps for types that uses id among U and T...
-  template<typename U, typename ...T>
-  struct id_maps_t<0, U, T...> : add_id_maps<0, is_use_id_t<U>::value, U, T...>
-  {
+  struct id_maps_t : std::enable_if_t<I == 0, 
+    add_id_maps<I, is_use_id_t<U>::value, U, T...>> {
     using add_id_maps<0, is_use_id_t<U>::value, U, T...>::id_map_infos;
     using typename add_id_maps<0, is_use_id_t<U>::value, U, T...>::num_id_maps;
     template<typename V, valid_use_id_t<V> = true>

--- a/runtime/obj/GarbageCollection.cpp
+++ b/runtime/obj/GarbageCollection.cpp
@@ -102,6 +102,9 @@ namespace gcfloatidmap {
   // Convert __raptor_fp * p to type T that do not use id
   template <typename T, valid_no_id_t<T> = true> 
   inline T get_f_from_p (__raptor_fp *p) { return raptor_bitcast<T>(p); }
+  // Get the id converted to type T that uses size_t id from __raptor_fp * p
+  template <typename T, use_id_t<T, size_t> = true>
+  inline T get_f_from_p (__raptor_fp *p) { return raptor_bitcast<T>(p->id.d); }
   // Get the id converted to type T that uses 32-bit id from __raptor_fp * p
   template <typename T, use_id_t<T, uint32_t> = true>
   inline T get_f_from_p (__raptor_fp *p) { return raptor_bitcast<T>(p->id.f); }

--- a/runtime/obj/GarbageCollection.cpp
+++ b/runtime/obj/GarbageCollection.cpp
@@ -117,9 +117,10 @@ namespace gcfloatidmap {
     using num_bits = std::integral_constant<unsigned, 
       sizeof(T) * std::numeric_limits<unsigned char>::digits>;
     if (id.d >= std::numeric_limits<fp_to_uint_t<T>>::max()) {
-      std::cerr << "Exceeding maximum number of " << (num_bits::value);
-      std::cerr << "-bit floating point values truncation in mem-mode.";
-      std::cerr << std::endl;
+      std::cerr << "Exceeding maximum number (";
+      std::cerr << std::numeric_limits<fp_to_uint_t<T>>::max() << ") of ";
+      std::cerr << "truncated " << num_bits::value << "-bit floating point ";
+      std::cerr << "values in mem-mode." << std::endl;
       abort();
     }
   }

--- a/test/Integration/Truncate/Cpp/simple.cpp
+++ b/test/Integration/Truncate/Cpp/simple.cpp
@@ -49,17 +49,29 @@ double intcast(int a) {
     return d / 3.14;
 }
 
+float constt_f(float a, float b) {
+    return 2;
+}
+void const_store_f(float *a) {
+    *a = 2.0;
+}
+
 typedef double (*fty)(double *, double *, double *, int);
 
 typedef double (*fty2)(double, double);
 
 template <typename fty> fty *__raptor_truncate_mem_func(fty *, int, int, int, int);
 template <typename fty> fty *__raptor_truncate_op_func(fty *, int, int, int, int);
-extern double __raptor_truncate_mem_value(...);
-extern double __raptor_expand_mem_value(...);
+extern double __raptor_truncate_mem_value(double, ...);
+extern double __raptor_expand_mem_value(double, ...);
+extern float __raptor_truncate_mem_value(float, ...);
+extern float __raptor_expand_mem_value(float, ...);
 
 #define FROM 64
 #define TO 1, 8, 23
+
+#define FROM_F 32
+#define TO_F 1, 8, 5
 
 #define TEST(F) do {
 
@@ -130,6 +142,24 @@ int main() {
     }
     {
         __raptor_truncate_mem_func(intcast, FROM, TO)(64);
+    }
+    {
+        float a = 2;
+        float b = 3;
+        float truth = constt_f(a, b);
+        a = __raptor_truncate_mem_value(a, FROM_F, TO_F);
+        b = __raptor_truncate_mem_value(b, FROM_F, TO_F);
+        float trunc = __raptor_truncate_mem_func(constt_f, FROM_F, TO_F)(a, b);
+        trunc = __raptor_expand_mem_value(trunc, FROM_F, TO_F);
+        APPROX_EQ(trunc, truth, 1e-5);
+    }
+    {
+        float truth = 0;
+        const_store_f(&truth);
+        float a = 0;
+        __raptor_truncate_mem_func(const_store_f, FROM_F, TO_F)(&a);
+        a = __raptor_expand_mem_value(a, FROM_F, TO_F);
+        APPROX_EQ(a, truth, 1e-5);
     }
     #endif
 


### PR DESCRIPTION
To retain `__raptor_fp` for native floating point variables across function boundaries, mem-mode stores the address of the `__raptor_fp` into the native floating point value to retrieve `__raptor_fp`.
However, this limits the mem-mode support to truncate from floating point types as large as a pointer (i.e. `double` on a 64-bit machine), since floating point types of smaller bit width is not able to hold the address of the `__raptor_fp`.

This pull request adds support for mem-mode truncation from floating point types that have smaller bit width than a pointer through assigning unique IDs as wide as the floating point type:
- A new vector of `__raptor_fp *` is added per C++ floating point types.
- Once a new `__raptor_fp` for a C++ floating point value is created, the address of the `__raptor_fp` is added to the vector for the corresponding C++ floating point type.
- The index in the vector for the `__raptor_fp *` is stored into the C++ floating point value as an ID.
- Across function boundaries, the C++ floating point value carries this ID, which is then used to index into the vector of corresponding C++ floating point type to retrieve the `__raptor_fp *`.

Since the unique IDs are as wide as the floating point type, this limits the number of floating point values that can be truncated. To handle this limitation:
- A runtime check is added where if a new ID to be assigned to a new `__raptor_fp` would exceed the limit of the corresponding native floating point type bit width, an error message will be printed before sending an abort signal.
- Upon the destruction of a `GCFloatTy`, the address of the `__raptor_fp` it contains is removed from the vector of `__raptor_fp *`, freeing up it's corresponding ID.
- A second vector of IDs is added per C++ floating point types to hold the pool free IDs.
- If there are any free IDs, a free ID is reused for a new `__raptor_fp` instead of incrementing the size of the `__raptor_fp *` vector to obtain new ID.

Compile-time constraints have also been added to check if the type used as input for mem-mode truncation is supported. 
Compile-time constraints also make sure that ID is not used when truncating from types as wide as a pointer, preserving the 64-bit truncation behavior. 
Using mem-mode truncation on unsupported types will result in compile time error (instead of the previous behavior of runtime abort).

While this pull request is independent, testing this feature with any floating point operations or standard math lib functions requires applying fixes for issue #10.