### PR TITLE
Fix mem-mode crashing with floating point literals

### DIFF
--- a/pass/RaptorLogic.cpp
+++ b/pass/RaptorLogic.cpp
@@ -937,6 +937,15 @@ public:
         if (FTT.isCallbackFunc()) {
           newCall->setArgOperand(FTT.getCallbackArgNo(), val);
         } else {
+          if (Mode == TruncMemMode){
+            for (unsigned i = 0; i < CI.arg_size(); ++i) {
+              auto arg = CI.getArgOperand(i);
+              if (arg->getType() == getFromType() && isa<ConstantFP>(arg)) {
+                newCall->setArgOperand(i, 
+                  truncate(BuilderZ, getNewFromOriginal(arg)));
+              }
+            }
+          }
           newCall->setCalledOperand(val);
         }
       }

--- a/pass/RaptorLogic.cpp
+++ b/pass/RaptorLogic.cpp
@@ -12,6 +12,7 @@
 #include "RaptorLogic.h"
 #include "Utils.h"
 #include "llvm-c/Core.h"
+#include "llvm/IR/AbstractCallSite.h"
 #include "llvm/IR/Constant.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DebugInfoMetadata.h"
@@ -934,19 +935,23 @@ public:
       assert(FTT.Func && !FTT.Func->empty());
       if (!NeedDirectCall(FTT)) {
         auto val = GetShadow(ctx, getNewFromOriginal(FTT.Func), false);
+        llvm::Use * u;
         if (FTT.isCallbackFunc()) {
           newCall->setArgOperand(FTT.getCallbackArgNo(), val);
+          u = CI.arg_begin() + FTT.getCallbackArgNo();
         } else {
-          if (Mode == TruncMemMode){
-            for (unsigned i = 0; i < CI.arg_size(); ++i) {
-              auto arg = CI.getArgOperand(i);
-              if (arg->getType() == getFromType() && isa<ConstantFP>(arg)) {
-                newCall->setArgOperand(i, 
-                  truncate(BuilderZ, getNewFromOriginal(arg)));
-              }
+          newCall->setCalledOperand(val);
+          u = &CI.getCalledOperandUse();
+        }
+        llvm::AbstractCallSite ACS(u);
+        if (Mode == TruncMemMode){
+          for (unsigned i = 0; i < ACS.getNumArgOperands(); ++i) {
+            auto arg = ACS.getCallArgOperand(i);
+            if (arg && arg->getType() == getFromType() && isa<ConstantFP>(arg)) {
+              newCall->setArgOperand(ACS.getCallArgOperandNo(i), 
+                truncate(BuilderZ, getNewFromOriginal(arg)));
             }
           }
-          newCall->setCalledOperand(val);
         }
       }
     }

--- a/test/Unit/Truncate/const.ll
+++ b/test/Unit/Truncate/const.ll
@@ -6,6 +6,11 @@ define double @f(double %x) {
   ret double %res
 }
 
+define double @g() {
+  %res = call double @f(double 2.000000e+00)
+  ret double %res
+}
+
 declare double (double)* @__raptor_truncate_mem_func(...)
 declare double (double)* @__raptor_truncate_op_func(...)
 
@@ -13,6 +18,12 @@ define double @tester(double %x) {
 entry:
   %ptr = call double (double)* (...) @__raptor_truncate_mem_func(double (double)* @f, i64 64, i64 0, i64 32)
   %res = call double %ptr(double %x)
+  ret double %res
+}
+define double @tester_mem_literal() {
+entry:
+  %ptr = call double (double)* (...) @__raptor_truncate_mem_func(double ()* @g, i64 64, i64 0, i64 32)
+  %res = call double %ptr()
   ret double %res
 }
 define double @tester_op_mpfr(double %x) {
@@ -25,6 +36,10 @@ entry:
 ; CHECK: define internal double @__raptor_done_truncate_mem_func_ieee_64_to_mpfr_8_23_0_0_0_f(double %x) {
 ; CHECK:   call double @__raptor_fprt_ieee_64_const(double 1.000000e+00, i64 8, i64 23, i64 1, {{.*}}
 ; CHECK:   call double @__raptor_fprt_ieee_64_binop_fadd(double {{.*}}, double %1, i64 8, i64 23, i64 1, {{.*}}
+
+; CHECK: define internal double @__raptor_done_truncate_mem_func_ieee_64_to_mpfr_8_23_0_0_0_g() {
+; CHECK:   call double @__raptor_fprt_ieee_64_const(double 2.000000e+00, i64 8, i64 23, i64 1, {{.*}}
+; CHECK:   call double @__raptor_done_truncate_mem_func_ieee_64_to_mpfr_8_23_0_1_0_f(double %1)
 
 ; CHECK: define internal double @__raptor_done_truncate_op_func_ieee_64_to_mpfr_3_7_1_1_0_f(double %x) {
 ; CHECK:   call double @__raptor_fprt_ieee_64_binop_fadd(double {{.*}}, double 1.000000e+00, i64 3, i64 7, i64 2

--- a/test/Unit/Truncate/const.ll
+++ b/test/Unit/Truncate/const.ll
@@ -6,8 +6,19 @@ define double @f(double %x) {
   ret double %res
 }
 
+declare !callback !0 double @callback_func_variadic_passed(ptr, ...)
+declare !callback !2 double @callback_func_variadic_not_passed(ptr, double, ...)
+
+define double @h(double %x, double %y) {
+  %res = fadd double %x, %y
+  ret double %res
+}
+
 define double @g() {
-  %res = call double @f(double 2.000000e+00)
+  %1 = call double @f(double 2.000000e+00)
+  %2 = call double (ptr, double, ...) @callback_func_variadic_not_passed(ptr nonnull @f, double 3.000000e+00, double %1)
+  %3 = call double (ptr, double, ...) @callback_func_variadic_not_passed(ptr nonnull @f, double %2, double 4.000000e+00)
+  %res = call double (ptr, ...) @callback_func_variadic_passed(ptr nonnull @h, double %3, double 5.000000e+00)
   ret double %res
 }
 
@@ -33,13 +44,24 @@ entry:
   ret double %res
 }
 
+!3 = !{i64 0, i64 1, i1 false}
+!2 = !{!3}
+
+!1 = !{i64 0, i1 true}
+!0 = !{!1}
+
 ; CHECK: define internal double @__raptor_done_truncate_mem_func_ieee_64_to_mpfr_8_23_0_0_0_f(double %x) {
 ; CHECK:   call double @__raptor_fprt_ieee_64_const(double 1.000000e+00, i64 8, i64 23, i64 1, {{.*}}
 ; CHECK:   call double @__raptor_fprt_ieee_64_binop_fadd(double {{.*}}, double %1, i64 8, i64 23, i64 1, {{.*}}
 
 ; CHECK: define internal double @__raptor_done_truncate_mem_func_ieee_64_to_mpfr_8_23_0_0_0_g() {
 ; CHECK:   call double @__raptor_fprt_ieee_64_const(double 2.000000e+00, i64 8, i64 23, i64 1, {{.*}}
-; CHECK:   call double @__raptor_done_truncate_mem_func_ieee_64_to_mpfr_8_23_0_1_0_f(double %1)
+; CHECK:   call double @__raptor_done_truncate_mem_func_ieee_64_to_mpfr_8_23_0_1_0_f(double %{{.*}})
+; CHECK:   call double @__raptor_fprt_ieee_64_const(double 3.000000e+00, i64 8, i64 23, i64 1, {{.*}}
+; CHECK:   call {{.*}} @callback_func_variadic_not_passed({{.*}}@__raptor_done_truncate_mem_func_ieee_64_to_mpfr_8_23_0_1_0_f, double %{{.*}}, double %{{.*}})
+; CHECK:   call {{.*}} @callback_func_variadic_not_passed({{.*}}@__raptor_done_truncate_mem_func_ieee_64_to_mpfr_8_23_0_1_0_f, double %{{.*}}, double 4.000000e+00)
+; CHECK:   call double @__raptor_fprt_ieee_64_const(double 5.000000e+00, i64 8, i64 23, i64 1, {{.*}}
+; CHECK:   call {{.*}} @callback_func_variadic_passed({{.*}}@__raptor_done_truncate_mem_func_ieee_64_to_mpfr_8_23_0_1_0_h, double %{{.*}}, double %{{.*}})
 
 ; CHECK: define internal double @__raptor_done_truncate_op_func_ieee_64_to_mpfr_3_7_1_1_0_f(double %x) {
 ; CHECK:   call double @__raptor_fprt_ieee_64_binop_fadd(double {{.*}}, double 1.000000e+00, i64 3, i64 7, i64 2


### PR DESCRIPTION
While intrinsics work fine, mem-mode crashes when floating point literals are used as input parameters to truncated functions.  An explicitly truncated function (created through `__raptor_truncate_mem_func()`) requires its input parameters truncated manually through `__raptor_truncate_mem_value()`, which does not have a problem with floating point literals, but functions truncated due to being transitively called by explicitly truncated functions cannot work around this problem with manual truncation.

This pull request fixes this problem by automatically creating a new truncated variable for literal inputs of truncated function transitively called by explicitly truncated ones, similar to how intrinsics are handled. Functions that have been explicitly truncated still has to have already truncated variables as input parameters.

This pull request also adds a manually constructed test case for this in the `test/Unit/Truncate/const.ll`.