### PR TITLE
LLVM 21 and 22 supposedly no longer have broken flang.

### DIFF
--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -24,9 +24,11 @@ jobs:
     steps:
     - name: add llvm
       run: |
+          sudo apt-get update
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
           sudo apt-add-repository "deb http://apt.llvm.org/`lsb_release -c | cut -f2`/ llvm-toolchain-`lsb_release -c | cut -f2`-${{ matrix.llvm }} main" || true
-          sudo apt-get install -y cmake gcc g++ python3 llvm-${{ matrix.llvm }}-dev libclang-${{ matrix.llvm }}-dev clang-${{ matrix.llvm }} lld-${{ matrix.llvm }} mlir-${{ matrix.llvm }}-tools libmlir-${{ matrix.llvm }} libmlir-${{ matrix.llvm }}-dev libflang-${{ matrix.llvm }}-dev flang-${{ matrix.llvm }} libzstd-dev libmpfr-dev libomp-${{ matrix.llvm }}-dev
+          sudo apt-get install -y cmake gcc g++ llvm-${{ matrix.llvm }}-dev libclang-${{ matrix.llvm }}-dev clang-${{ matrix.llvm }} lld-${{ matrix.llvm }} mlir-${{ matrix.llvm }}-tools libmlir-${{ matrix.llvm }} libmlir-${{ matrix.llvm }}-dev libflang-${{ matrix.llvm }}-dev flang-${{ matrix.llvm }} libzstd-dev libmpfr-dev libomp-${{ matrix.llvm }}-dev
+          sudo apt-get install --only-upgrade python3-pip
           sudo python3 -m pip install --upgrade pip lit
     - uses: actions/checkout@v4
     - name: mkdir

--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -15,15 +15,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        llvm: ["20", "21", "22"]
+        llvm: ["20", "21"] #, "22"]
         build: ["Release"] #, "Debug"] #, "RelWithDebInfo"]
-        os: ["ubuntu-22.04", "ubuntu-24.04", "ubuntu-26.04"]
+        os: ["ubuntu-24.04", "ubuntu-26.04"]
 
     timeout-minutes: 30
 
     steps:
     - name: add llvm
       run: |
+          sudo apt-update
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
           sudo apt-add-repository "deb http://apt.llvm.org/`lsb_release -c | cut -f2`/ llvm-toolchain-`lsb_release -c | cut -f2`-${{ matrix.llvm }} main" || true
           sudo apt-get install -y cmake gcc g++ llvm-${{ matrix.llvm }}-dev libclang-${{ matrix.llvm }}-dev clang-${{ matrix.llvm }} lld-${{ matrix.llvm }} mlir-${{ matrix.llvm }}-tools libmlir-${{ matrix.llvm }} libmlir-${{ matrix.llvm }}-dev libflang-${{ matrix.llvm }}-dev flang-${{ matrix.llvm }} libzstd-dev libmpfr-dev libomp-${{ matrix.llvm }}-dev

--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -24,10 +24,9 @@ jobs:
     steps:
     - name: add llvm
       run: |
-          sudo apt-get update
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
           sudo apt-add-repository "deb http://apt.llvm.org/`lsb_release -c | cut -f2`/ llvm-toolchain-`lsb_release -c | cut -f2`-${{ matrix.llvm }} main" || true
-          sudo apt-get install -y cmake gcc g++ llvm-${{ matrix.llvm }}-dev libclang-${{ matrix.llvm }}-dev clang-${{ matrix.llvm }} lld-${{ matrix.llvm }} mlir-${{ matrix.llvm }}-tools libmlir-${{ matrix.llvm }} libmlir-${{ matrix.llvm }}-dev libflang-${{ matrix.llvm }}-dev flang-${{ matrix.llvm }} libzstd-dev libmpfr-dev libomp-${{ matrix.llvm }}-dev
+          sudo apt-get install -y cmake gcc g++ python3 llvm-${{ matrix.llvm }}-dev libclang-${{ matrix.llvm }}-dev clang-${{ matrix.llvm }} lld-${{ matrix.llvm }} mlir-${{ matrix.llvm }}-tools libmlir-${{ matrix.llvm }} libmlir-${{ matrix.llvm }}-dev libflang-${{ matrix.llvm }}-dev flang-${{ matrix.llvm }} libzstd-dev libmpfr-dev libomp-${{ matrix.llvm }}-dev
           sudo python3 -m pip install --upgrade pip lit
     - uses: actions/checkout@v4
     - name: mkdir

--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        llvm: ["20", "21"] #, "22"]
+        llvm: ["20", "21", "22"]
         build: ["Release"] #, "Debug"] #, "RelWithDebInfo"]
-        os: ["ubuntu-24.04", "ubuntu-26.04"]
+        os: ["ubuntu-22.04", "ubuntu-24.04", "ubuntu-26.04"]
 
     timeout-minutes: 30
 

--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         llvm: ["20", "21", "22"]
         build: ["Release"] #, "Debug"] #, "RelWithDebInfo"]
-        os: ["ubuntu-22.04", "ubuntu-24.04" "ubuntu-26.04"]
+        os: ["ubuntu-22.04", "ubuntu-24.04", "ubuntu-26.04"]
 
     timeout-minutes: 30
 

--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - name: add llvm
       run: |
-          sudo apt-update
+          sudo apt-get update
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
           sudo apt-add-repository "deb http://apt.llvm.org/`lsb_release -c | cut -f2`/ llvm-toolchain-`lsb_release -c | cut -f2`-${{ matrix.llvm }} main" || true
           sudo apt-get install -y cmake gcc g++ llvm-${{ matrix.llvm }}-dev libclang-${{ matrix.llvm }}-dev clang-${{ matrix.llvm }} lld-${{ matrix.llvm }} mlir-${{ matrix.llvm }}-tools libmlir-${{ matrix.llvm }} libmlir-${{ matrix.llvm }}-dev libflang-${{ matrix.llvm }}-dev flang-${{ matrix.llvm }} libzstd-dev libmpfr-dev libomp-${{ matrix.llvm }}-dev

--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        llvm: ["20", "21", "22"]
+        llvm: ["20", "21"] #, "22"]
         build: ["Release"] #, "Debug"] #, "RelWithDebInfo"]
         os: ["ubuntu-22.04", "ubuntu-24.04", "ubuntu-26.04"]
         exclude:

--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -26,7 +26,10 @@ jobs:
       run: |
           source /etc/os-release
           sudo mkdir -p /etc/apt/keyrings
-          sudo wget -O /etc/apt/keyrings/llvm-snapshot.gpg https://apt.llvm.org/llvm-snapshot.gpg.key
+          wget https://apt.llvm.org/llvm-snapshot.gpg.key
+          gpg --no-default-keyring --keyring ./temp-keyring.gpg --import llvm-snapshot.gpg.key
+          sudo gpg --no-default-keyring --keyring ./temp-keyring.gpg --export --output /etc/apt/keyrings/llvm-snapshot.gpg
+          rm temp-keyring.gpg
           sudo apt-add-repository "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-${{ matrix.llvm }} main" || true
           sudo sed -i 's/^deb /deb [signed-by=\/etc\/apt\/keyrings\/llvm-snapshot.gpg] /' "/etc/apt/sources.list.d/archive_uri-http_apt_llvm_org_${UBUNTU_CODENAME}_-${UBUNTU_CODENAME}.list"
           sudo apt-get install -y cmake gcc g++ llvm-${{ matrix.llvm }}-dev libclang-${{ matrix.llvm }}-dev clang-${{ matrix.llvm }} lld-${{ matrix.llvm }} mlir-${{ matrix.llvm }}-tools libmlir-${{ matrix.llvm }} libmlir-${{ matrix.llvm }}-dev libflang-${{ matrix.llvm }}-dev flang-${{ matrix.llvm }} libzstd-dev libmpfr-dev libomp-${{ matrix.llvm }}-dev

--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        llvm: ["20", "21"]
+        llvm: ["20", "21", "22"]
         build: ["Release"] #, "Debug"] #, "RelWithDebInfo"]
-        os: [ubuntu-22.04]
+        os: ["ubuntu-22.04", "ubuntu-24.04" "ubuntu-26.04"]
 
     timeout-minutes: 30
 

--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -24,12 +24,10 @@ jobs:
     steps:
     - name: add llvm
       run: |
-          sudo apt-get update
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
           sudo apt-add-repository "deb http://apt.llvm.org/`lsb_release -c | cut -f2`/ llvm-toolchain-`lsb_release -c | cut -f2`-${{ matrix.llvm }} main" || true
           sudo apt-get install -y cmake gcc g++ llvm-${{ matrix.llvm }}-dev libclang-${{ matrix.llvm }}-dev clang-${{ matrix.llvm }} lld-${{ matrix.llvm }} mlir-${{ matrix.llvm }}-tools libmlir-${{ matrix.llvm }} libmlir-${{ matrix.llvm }}-dev libflang-${{ matrix.llvm }}-dev flang-${{ matrix.llvm }} libzstd-dev libmpfr-dev libomp-${{ matrix.llvm }}-dev
-          sudo apt-get install --only-upgrade python3-pip
-          sudo python3 -m pip install --upgrade pip lit
+          sudo python3 -m pip install lit
     - uses: actions/checkout@v4
     - name: mkdir
       run: rm -rf build && mkdir build

--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -18,6 +18,10 @@ jobs:
         llvm: ["20", "21", "22"]
         build: ["Release"] #, "Debug"] #, "RelWithDebInfo"]
         os: ["ubuntu-22.04", "ubuntu-24.04", "ubuntu-26.04"]
+        exclude:
+          # LLVM 20 not available for ubuntu-26.04 in apt.llvm.org
+          - os: "ubuntu-26.04"
+            llvm: "20"
 
     timeout-minutes: 30
 

--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -29,9 +29,10 @@ jobs:
           wget https://apt.llvm.org/llvm-snapshot.gpg.key
           gpg --no-default-keyring --keyring ./temp-keyring.gpg --import llvm-snapshot.gpg.key
           sudo gpg --no-default-keyring --keyring ./temp-keyring.gpg --export --output /etc/apt/keyrings/llvm-snapshot.gpg
-          rm temp-keyring.gpg
+          rm ./temp-keyring.gpg
           sudo apt-add-repository "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-${{ matrix.llvm }} main" || true
           sudo sed -i 's/^deb /deb [signed-by=\/etc\/apt\/keyrings\/llvm-snapshot.gpg] /' "/etc/apt/sources.list.d/archive_uri-http_apt_llvm_org_${UBUNTU_CODENAME}_-${UBUNTU_CODENAME}.list"
+          sudo apt-get update
           sudo apt-get install -y cmake gcc g++ llvm-${{ matrix.llvm }}-dev libclang-${{ matrix.llvm }}-dev clang-${{ matrix.llvm }} lld-${{ matrix.llvm }} mlir-${{ matrix.llvm }}-tools libmlir-${{ matrix.llvm }} libmlir-${{ matrix.llvm }}-dev libflang-${{ matrix.llvm }}-dev flang-${{ matrix.llvm }} libzstd-dev libmpfr-dev libomp-${{ matrix.llvm }}-dev
           sudo python3 -m pip install lit
     - uses: actions/checkout@v4

--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -24,8 +24,11 @@ jobs:
     steps:
     - name: add llvm
       run: |
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-          sudo apt-add-repository "deb http://apt.llvm.org/`lsb_release -c | cut -f2`/ llvm-toolchain-`lsb_release -c | cut -f2`-${{ matrix.llvm }} main" || true
+          source /etc/os-release
+          sudo mkdir -p /etc/apt/keyrings
+          wget -O /etc/apt/keyrings/llvm-snapshot.gpg https://apt.llvm.org/llvm-snapshot.gpg.key
+          sudo apt-add-repository "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-${{ matrix.llvm }} main" || true
+          sed -i 's/^deb /deb [signed-by=\/etc\/apt\/keyrings\/llvm-snapshot.gpg] /' "/etc/apt/sources.list.d/archive_uri-http_apt_llvm_org_${UBUNTU_CODENAME}_-${UBUNTU_CODENAME}.list"
           sudo apt-get install -y cmake gcc g++ llvm-${{ matrix.llvm }}-dev libclang-${{ matrix.llvm }}-dev clang-${{ matrix.llvm }} lld-${{ matrix.llvm }} mlir-${{ matrix.llvm }}-tools libmlir-${{ matrix.llvm }} libmlir-${{ matrix.llvm }}-dev libflang-${{ matrix.llvm }}-dev flang-${{ matrix.llvm }} libzstd-dev libmpfr-dev libomp-${{ matrix.llvm }}-dev
           sudo python3 -m pip install lit
     - uses: actions/checkout@v4

--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -26,9 +26,9 @@ jobs:
       run: |
           source /etc/os-release
           sudo mkdir -p /etc/apt/keyrings
-          wget -O /etc/apt/keyrings/llvm-snapshot.gpg https://apt.llvm.org/llvm-snapshot.gpg.key
+          sudo wget -O /etc/apt/keyrings/llvm-snapshot.gpg https://apt.llvm.org/llvm-snapshot.gpg.key
           sudo apt-add-repository "deb http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-${{ matrix.llvm }} main" || true
-          sed -i 's/^deb /deb [signed-by=\/etc\/apt\/keyrings\/llvm-snapshot.gpg] /' "/etc/apt/sources.list.d/archive_uri-http_apt_llvm_org_${UBUNTU_CODENAME}_-${UBUNTU_CODENAME}.list"
+          sudo sed -i 's/^deb /deb [signed-by=\/etc\/apt\/keyrings\/llvm-snapshot.gpg] /' "/etc/apt/sources.list.d/archive_uri-http_apt_llvm_org_${UBUNTU_CODENAME}_-${UBUNTU_CODENAME}.list"
           sudo apt-get install -y cmake gcc g++ llvm-${{ matrix.llvm }}-dev libclang-${{ matrix.llvm }}-dev clang-${{ matrix.llvm }} lld-${{ matrix.llvm }} mlir-${{ matrix.llvm }}-tools libmlir-${{ matrix.llvm }} libmlir-${{ matrix.llvm }}-dev libflang-${{ matrix.llvm }}-dev flang-${{ matrix.llvm }} libzstd-dev libmpfr-dev libomp-${{ matrix.llvm }}-dev
           sudo python3 -m pip install lit
     - uses: actions/checkout@v4

--- a/pass/Raptor.cpp
+++ b/pass/Raptor.cpp
@@ -1276,7 +1276,11 @@ public:
 
 } // namespace
 
+#if LLVM_VERSION_MAJOR >= 22
+#include "llvm/Extensions/PassPlugin.h"
+#else
 #include "llvm/Passes/PassPlugin.h"
+#endif
 
 class RaptorNewPM final : public RaptorBase,
                           public AnalysisInfoMixin<RaptorNewPM> {

--- a/test/Integration/Truncate/Fortran/simple-no-bindc.f90
+++ b/test/Integration/Truncate/Fortran/simple-no-bindc.f90
@@ -1,6 +1,3 @@
-! ! Circumvent tests in versions where LLVM ships with a non-functional flang
-! ! (see https://github.com/llvm/llvm-project/issues/138340 )
-! XFAIL: llvm-major={{21|22}}
 ! RUN: %flang -O1 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s
 ! RUN: %flang -O2 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s
 ! RUN: %flang -O3 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s

--- a/test/Integration/Truncate/Fortran/simple.f90
+++ b/test/Integration/Truncate/Fortran/simple.f90
@@ -1,6 +1,3 @@
-! ! Circumvent tests in versions where LLVM ships with a non-functional flang
-! ! (see https://github.com/llvm/llvm-project/issues/138340 )
-! UNSUPPORTED: llvm-major={{21|22}}
 ! RUN: %flang -O0 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s
 ! RUN: %flang -O1 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s
 ! RUN: %flang -O2 %s -o %t.a.out %loadFlangRaptor %linkRaptorRT -lm -lmpfr && %t.a.out 100000 2 | FileCheck %s


### PR DESCRIPTION
So test/Integration/Truncate/Fortran/simple.f90 and test/Integration/Truncate/Fortran/simple-no-bindc.f90 should work for LLVM 21 and 22 on Ubuntu. Also added Ubuntu 24.04 and 26.04 active LTS releases.